### PR TITLE
Feature/#8  회원 도메인 엔티티 및 Repository 구조 생성

### DIFF
--- a/backend/user-service/src/main/java/com/bidket/user/domain/model/PointAccountStatus.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/model/PointAccountStatus.java
@@ -1,0 +1,7 @@
+package com.bidket.user.domain.model;
+
+public enum PointAccountStatus {
+    ACTIVE,
+    SUSPENDED
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/domain/model/PointHistoryType.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/model/PointHistoryType.java
@@ -1,0 +1,9 @@
+package com.bidket.user.domain.model;
+
+public enum PointHistoryType {
+    CHARGE,
+    USE,
+    REFUND,
+    CANCEL
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/domain/model/Provider.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/model/Provider.java
@@ -1,0 +1,8 @@
+package com.bidket.user.domain.model;
+
+public enum Provider {
+    LOCAL,
+    KAKAO,
+    GOOGLE
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/domain/model/UserStatus.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/model/UserStatus.java
@@ -1,0 +1,8 @@
+package com.bidket.user.domain.model;
+
+public enum UserStatus {
+    ACTIVE,
+    SUSPENDED,
+    WITHDRAWN
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/PointAccount.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/PointAccount.java
@@ -1,0 +1,60 @@
+package com.bidket.user.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import com.bidket.user.domain.model.PointAccountStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_point_account")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointAccount extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id", columnDefinition = "UUID")
+    private UUID userId;
+
+    @Column(name = "balance", nullable = false)
+    private Long balance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PointAccountStatus status;
+
+    @Builder
+    public PointAccount(UUID userId, Long balance, PointAccountStatus status) {
+        this.userId = userId;
+        this.balance = balance != null ? balance : 0L;
+        this.status = status != null ? status : PointAccountStatus.ACTIVE;
+    }
+
+    public void addBalance(Long amount) {
+        this.balance += amount;
+    }
+
+    public void subtractBalance(Long amount) {
+        if (this.balance < amount) {
+            throw new IllegalArgumentException("잔액이 부족합니다.");
+        }
+        this.balance -= amount;
+    }
+
+    public void suspend() {
+        this.status = PointAccountStatus.SUSPENDED;
+    }
+
+    public void activate() {
+        this.status = PointAccountStatus.ACTIVE;
+    }
+
+    public boolean hasEnoughBalance(Long amount) {
+        return this.balance >= amount;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/PointHistory.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/PointHistory.java
@@ -1,0 +1,56 @@
+package com.bidket.user.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import com.bidket.user.domain.model.PointHistoryType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_point_history", indexes = {
+        @Index(name = "idx_p_point_history_user_id", columnList = "user_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, columnDefinition = "UUID")
+    private UUID userId;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 30)
+    private PointHistoryType type;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Column(name = "order_id", columnDefinition = "UUID")
+    private UUID orderId;
+
+    @Column(name = "balance_after", nullable = false)
+    private Long balanceAfter;
+
+    @Builder
+    public PointHistory(UUID userId, Long amount, PointHistoryType type, 
+                       String description, UUID orderId, Long balanceAfter) {
+        this.userId = userId;
+        this.amount = amount;
+        this.type = type;
+        this.description = description;
+        this.orderId = orderId;
+        this.balanceAfter = balanceAfter;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/RefreshToken.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/RefreshToken.java
@@ -1,0 +1,61 @@
+package com.bidket.user.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_refresh_token", indexes = {
+        @Index(name = "idx_refresh_user_id", columnList = "user_id"),
+        @Index(name = "idx_refresh_expires_at", columnList = "expires_at")
+}, uniqueConstraints = {
+        @UniqueConstraint(name = "uk_refresh_token", columnNames = "token")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, columnDefinition = "UUID")
+    private UUID userId;
+
+    @Column(name = "token", nullable = false, columnDefinition = "TEXT")
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked", nullable = false)
+    private Boolean revoked;
+
+    @Builder
+    public RefreshToken(UUID userId, String token, LocalDateTime expiresAt, Boolean revoked) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.revoked = revoked != null ? revoked : false;
+    }
+
+    public void revoke() {
+        this.revoked = true;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+
+    public boolean isValid() {
+        return !this.revoked && !isExpired();
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/Role.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/Role.java
@@ -1,0 +1,39 @@
+package com.bidket.user.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_role", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_role_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Role extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "code", nullable = false, unique = true, length = 30)
+    private String code;
+
+    @Column(name = "name", length = 50)
+    private String name;
+
+    @Builder
+    public Role(String code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
@@ -1,0 +1,108 @@
+package com.bidket.user.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import com.bidket.user.domain.model.Provider;
+import com.bidket.user.domain.model.UserStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_user", indexes = {
+        @Index(name = "idx_user_provider", columnList = "provider"),
+        @Index(name = "idx_user_nickname", columnList = "nickname")
+}, uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_email", columnNames = "email"),
+        @UniqueConstraint(name = "uk_user_provider_provider_id", columnNames = {"provider", "provider_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(name = "login_id", length = 30)
+    private String loginId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 50)
+    private Provider provider;
+
+    @Column(name = "provider_id", length = 255)
+    private String providerId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "nickname", length = 100)
+    private String nickname;
+
+    @Column(name = "phone", length = 20)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private UserStatus status;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Builder
+    public User(String loginId, Provider provider, String providerId, String name, 
+                  String password, String email, String nickname, String phone, UserStatus status) {
+        this.loginId = loginId;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.nickname = nickname;
+        this.phone = phone;
+        this.status = status != null ? status : UserStatus.ACTIVE;
+    }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    public void updateProfile(String name, String nickname, String phone) {
+        this.name = name;
+        this.nickname = nickname;
+        this.phone = phone;
+    }
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    public void suspend() {
+        this.status = UserStatus.SUSPENDED;
+    }
+
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAWN;
+    }
+
+    public boolean isLocalProvider() {
+        return this.provider == Provider.LOCAL;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/UserBlacklist.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/UserBlacklist.java
@@ -1,0 +1,63 @@
+package com.bidket.user.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_user_blacklist")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBlacklist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, columnDefinition = "UUID")
+    private UUID userId;
+
+    @Column(name = "reason", nullable = false, length = 255)
+    private String reason;
+
+    @Column(name = "expire_at")
+    private LocalDateTime expireAt;
+
+    @Column(name = "active", nullable = false)
+    private Boolean active;
+
+    @Builder
+    public UserBlacklist(UUID userId, String reason, LocalDateTime expireAt, Boolean active) {
+        this.userId = userId;
+        this.reason = reason;
+        this.expireAt = expireAt;
+        this.active = active != null ? active : true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public boolean isExpired() {
+        if (this.expireAt == null) {
+            return false; // 무기한 블랙리스트
+        }
+        return LocalDateTime.now().isAfter(this.expireAt);
+    }
+
+    public boolean isValid() {
+        return this.active && !isExpired();
+    }
+}
+


### PR DESCRIPTION
## Issue Number
- closed #[8]

## Description
- Member 엔티티를 User로 변경 (파일명, 클래스명, 모든 참조)
- 6개 엔티티 생성: User, Role, RefreshToken, UserBlacklist, PointAccount, PointHistory
- 테이블명 및 컬럼명 변경: member_id → user_id
- DDD 컨벤션에 맞게 infrastructure/persistence/entity 구조로 정리
- 테이블 생성 확인 완료

## Test Result
- 테스트 결과 이미지
![User테이블생성](https://github.com/user-attachments/assets/e6ce9474-8137-41a4-9939-a83cb123af96)



## To Reviewer
- 리뷰 포인트 : 엔티티 및 Repository 구조의 변경 사항, 테이블명 수정 관련 검토
