### PR TITLE
Feat/#5 queue entrance

### DIFF
--- a/backend/queue-service/build.gradle
+++ b/backend/queue-service/build.gradle
@@ -20,4 +20,9 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     implementation 'com.github.Bidket:bidket-common-repo:main-SNAPSHOT'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'com.h2database:h2'
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/QueueServiceApplication.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/QueueServiceApplication.java
@@ -3,8 +3,10 @@ package com.bidket.queue;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = {RedisRepositoriesAutoConfiguration.class})
+@EnableScheduling
 public class QueueServiceApplication {
 
     public static void main(String[] args) {

--- a/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class QueueService {
     private final RedisRepository redisRepository;
-    private final TokenProvider tokenProvider;
 
     public Mono<QueueCreateResponse> createConfigQueue(QueueCreateRequest request) {
         String key = "queue:auction:" + request.auctionId() + ":config";

--- a/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
@@ -64,6 +64,7 @@ public class QueueService {
                 .switchIfEmpty(Mono.error(new QueueException(QueueErrorCode.CONFIG_NOT_FOUND)))
                 .flatMap(config -> {
                     config.checkOpenStatus(Instant.now());
+                    log.info("사용자[{}]: 대기열 입장[{}]", userId, waitingKey);
                     return redisRepository.addWaitingUser(waitingKey, userId);
                 })
                 .flatMap(isAdded -> redisRepository.getRank(waitingKey, userId))

--- a/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
@@ -1,18 +1,28 @@
 package com.bidket.queue.application.service;
 
+import com.bidket.queue.domain.jwt.TokenProvider;
 import com.bidket.queue.domain.repository.RedisRepository;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
+import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class QueueService {
     private final RedisRepository redisRepository;
+    private final TokenProvider tokenProvider;
 
-    public Mono<QueueCreateResponse> createQueue(QueueCreateRequest request) {
+    public Mono<QueueCreateResponse> createConfigQueue(QueueCreateRequest request) {
         return redisRepository.createQueueConfig(request);
+    }
+
+    public Mono<QueueEnterResponse> queueEntrance(UUID userId, UUID auctionId) {
+        tokenProvider.generateToken(userId, auctionId);
+        return null;
     }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/application/service/QueueService.java
@@ -1,6 +1,6 @@
 package com.bidket.queue.application.service;
 
-import com.bidket.queue.infrastructure.redis.RedisRepository;
+import com.bidket.queue.domain.repository.RedisRepository;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
 import lombok.RequiredArgsConstructor;

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/jwt/TokenProvider.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/jwt/TokenProvider.java
@@ -1,7 +1,11 @@
 package com.bidket.queue.domain.jwt;
 
+import org.springframework.web.reactive.function.server.ServerRequest;
+
 import java.util.UUID;
 
 public interface TokenProvider {
     String generateToken(UUID userId, UUID auctionId);
+    String extractToken(ServerRequest request);
+    boolean validateToken(String token, UUID userId, UUID auctionId);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/jwt/TokenProvider.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/jwt/TokenProvider.java
@@ -1,0 +1,7 @@
+package com.bidket.queue.domain.jwt;
+
+import java.util.UUID;
+
+public interface TokenProvider {
+    String generateToken(UUID userId, UUID auctionId);
+}

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
@@ -15,6 +15,7 @@ public class QueueConfigModel {
     private UUID auctionId;
     @Getter
     private Long maxActive;
+    @Getter
     private Integer permitsPerSec;
     private Instant openAt;
     @Getter

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
@@ -17,12 +17,13 @@ public class QueueConfigModel {
     private Long maxActive;
     private Integer permitsPerSec;
     private Instant openAt;
+    @Getter
     private Instant closeAt;
 
-    public Map<String, Object> toMap() {
-        return Map.of("auctionId", auctionId,
-                "max_active", maxActive,
-                "permits_per_sec", permitsPerSec,
+    public Map<String, String> toMap() {
+        return Map.of("auctionId", auctionId.toString(),
+                "max_active", maxActive.toString(),
+                "permits_per_sec", permitsPerSec.toString(),
                 "open_at", openAt.toString(),
                 "close_at", closeAt.toString());
     }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
@@ -1,19 +1,23 @@
 package com.bidket.queue.domain.model;
 
+import com.bidket.queue.domain.exception.QueueException;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
 import lombok.Builder;
+import lombok.Getter;
+import reactor.core.publisher.Mono;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
 @Builder
 public class QueueConfigModel {
     private UUID auctionId;
+    @Getter
     private Long maxActive;
     private Integer permitsPerSec;
-    private LocalDateTime openAt;
-    private LocalDateTime closeAt;
+    private Instant openAt;
+    private Instant closeAt;
 
     public Map<String, Object> toMap() {
         return Map.of("auctionId", auctionId,
@@ -31,5 +35,12 @@ public class QueueConfigModel {
                 .openAt(openAt)
                 .closeAt(closeAt)
                 .build();
+    }
+
+    public void checkOpenStatus(Instant now) {
+        if(now.isBefore(openAt))
+            throw new QueueException(QueueErrorCode.AUCTION_NOT_OPENED);
+        if(now.isAfter(closeAt))
+            throw new QueueException(QueueErrorCode.AUCTION_CLOSED);
     }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueConfigModel.java
@@ -23,10 +23,10 @@ public class QueueConfigModel {
 
     public Map<String, String> toMap() {
         return Map.of("auctionId", auctionId.toString(),
-                "max_active", maxActive.toString(),
-                "permits_per_sec", permitsPerSec.toString(),
-                "open_at", openAt.toString(),
-                "close_at", closeAt.toString());
+                "maxActive", maxActive.toString(),
+                "permitsPerSec", permitsPerSec.toString(),
+                "openAt", openAt.toString(),
+                "closeAt", closeAt.toString());
     }
 
     public QueueCreateResponse toCreateResponse() {

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueErrorCode.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueErrorCode.java
@@ -10,7 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum QueueErrorCode implements BaseErrorCode {
     REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 연결 오류 발생"),
     REDIS_EXPIRE_SET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TTL 설정 중 오류 발생"),
-    REDIS_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 저장 실패");
+    REDIS_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 저장 실패"),
+
+    INVALID_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 Active Token"),
+    CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 설정이 없습니다."),
+
+    AUCTION_CLOSED(HttpStatus.FORBIDDEN, "이미 종료된 경매입니다."),
+    AUCTION_NOT_OPENED(HttpStatus.FORBIDDEN, "경매 오픈 전입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueErrorCode.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/model/QueueErrorCode.java
@@ -14,6 +14,7 @@ public enum QueueErrorCode implements BaseErrorCode {
 
     INVALID_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 Active Token"),
     CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 설정이 없습니다."),
+    AUCTION_REGISTER_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "경매 캐싱 등록 실패"),
 
     AUCTION_CLOSED(HttpStatus.FORBIDDEN, "이미 종료된 경매입니다."),
     AUCTION_NOT_OPENED(HttpStatus.FORBIDDEN, "경매 오픈 전입니다.");

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -1,10 +1,11 @@
 package com.bidket.queue.domain.repository;
 
 import com.bidket.queue.domain.model.QueueConfigModel;
-import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public interface RedisRepository {
@@ -12,13 +13,25 @@ public interface RedisRepository {
 
     Mono<QueueConfigModel> getConfig(String configKey);
 
-    Mono<Boolean> setConfigExpiration(String configKey, Instant expireAt);
+    Mono<Boolean> setExpiration(String configKey, Instant expireAt);
 
     Mono<Boolean> deleteConfig(String configKey);
 
+    Mono<Long> registerActiveAuction(UUID auctionId);
+
+    Flux<UUID> getAllActiveAuctions();
+
+    Mono<Long> removeActiveAuction(UUID auctionId);
+
     Mono<Boolean> addActiveUser(String activeKey, Long maxUser, UUID userId);
 
+    Mono<Long> addAllActiveUser(String activeKey, List<UUID> userIds);
+
+    Mono<Long> activeUserCount(String activeKey);
+
     Mono<Boolean> addWaitingUser(String waitingKey, UUID userId);
+
+    Mono<List<UUID>> popUserIdWaitingQueue(String waitingKey, long limit);
 
     Mono<Long> getRank(String waitingKey, UUID userId);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -1,10 +1,12 @@
 package com.bidket.queue.domain.repository;
 
+import com.bidket.queue.domain.model.QueueConfigModel;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
 import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public interface RedisRepository {
@@ -14,7 +16,8 @@ public interface RedisRepository {
 
     Mono<Boolean> deleteValue(String key);
 
-    Mono<QueueCreateResponse> createQueueConfig(QueueCreateRequest request);
+    Mono<Boolean> saveConfig(String configKey, QueueConfigModel model);
+    Mono<Boolean> setConfigExpiration(String configKey, Instant expireAt);
 
     Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -1,4 +1,4 @@
-package com.bidket.queue.infrastructure.redis;
+package com.bidket.queue.domain.repository;
 
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -2,7 +2,10 @@ package com.bidket.queue.domain.repository;
 
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
+import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 public interface RedisRepository {
     Mono<Object> getValue(String key);
@@ -12,4 +15,6 @@ public interface RedisRepository {
     Mono<Boolean> deleteValue(String key);
 
     Mono<QueueCreateResponse> createQueueConfig(QueueCreateRequest request);
+
+    Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -6,6 +6,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface RedisRepository {
@@ -34,4 +35,6 @@ public interface RedisRepository {
     Mono<List<UUID>> popUserIdWaitingQueue(String waitingKey, long limit);
 
     Mono<Long> getRank(String waitingKey, UUID userId);
+
+    Mono<Boolean> saveToken(String tokenKey, Map<UUID, String> tokens);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -10,9 +10,17 @@ import java.util.UUID;
 public interface RedisRepository {
     Mono<Boolean> saveConfig(String configKey, QueueConfigModel model);
 
+    Mono<QueueConfigModel> getConfig(String configKey);
+
     Mono<Boolean> setConfigExpiration(String configKey, Instant expireAt);
 
     Mono<Boolean> deleteConfig(String configKey);
 
     Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId);
+
+    Mono<Boolean> addActiveUser(String activeKey, Long maxUser, UUID userId);
+
+    Mono<Boolean> addWaitingUser(String waitingKey, UUID userId);
+
+    Mono<Long> getRank(String waitingKey, UUID userId);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -16,8 +16,6 @@ public interface RedisRepository {
 
     Mono<Boolean> deleteConfig(String configKey);
 
-    Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId);
-
     Mono<Boolean> addActiveUser(String activeKey, Long maxUser, UUID userId);
 
     Mono<Boolean> addWaitingUser(String waitingKey, UUID userId);

--- a/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/domain/repository/RedisRepository.java
@@ -1,8 +1,6 @@
 package com.bidket.queue.domain.repository;
 
 import com.bidket.queue.domain.model.QueueConfigModel;
-import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
-import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
 import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
 import reactor.core.publisher.Mono;
 
@@ -10,14 +8,11 @@ import java.time.Instant;
 import java.util.UUID;
 
 public interface RedisRepository {
-    Mono<Object> getValue(String key);
-
-    Mono<Boolean> setValue(String key, Object value);
-
-    Mono<Boolean> deleteValue(String key);
-
     Mono<Boolean> saveConfig(String configKey, QueueConfigModel model);
+
     Mono<Boolean> setConfigExpiration(String configKey, Instant expireAt);
+
+    Mono<Boolean> deleteConfig(String configKey);
 
     Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId);
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/jwt/TokenProviderImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/jwt/TokenProviderImpl.java
@@ -1,0 +1,24 @@
+package com.bidket.queue.infrastructure.jwt;
+
+import com.bidket.queue.domain.jwt.TokenProvider;
+import io.jsonwebtoken.Jwts;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+public class TokenProviderImpl implements TokenProvider {
+    private Key key;
+
+    @Override
+    public String generateToken(UUID userId, UUID auctionId) {
+        return Jwts.builder()
+                .claim("userId", userId)
+                .claim("acutionId", auctionId)
+                .setIssuedAt(Date.from(Instant.now()))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/jwt/TokenProviderImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/jwt/TokenProviderImpl.java
@@ -2,22 +2,29 @@ package com.bidket.queue.infrastructure.jwt;
 
 import com.bidket.queue.domain.jwt.TokenProvider;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 
 import javax.crypto.SecretKey;
-import java.security.Key;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
 public class TokenProviderImpl implements TokenProvider {
-    private Key key;
+    @Value("${jwt.secret}")
+    private String secret;
+    @Value("${jwt.expiration}")
+    private long expiration;
 
     @Override
     public String generateToken(UUID userId, UUID auctionId) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secret));
         return Jwts.builder()
                 .claim("userId", userId)
                 .claim("acutionId", auctionId)
                 .setIssuedAt(Date.from(Instant.now()))
+                .setExpiration(Date.from(Instant.now().plusSeconds(expiration)))
                 .signWith(key)
                 .compact();
     }

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/jwt/TokenProviderImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/jwt/TokenProviderImpl.java
@@ -1,16 +1,21 @@
 package com.bidket.queue.infrastructure.jwt;
 
+import com.bidket.queue.domain.exception.QueueException;
 import com.bidket.queue.domain.jwt.TokenProvider;
+import com.bidket.queue.domain.model.QueueErrorCode;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
 
 import javax.crypto.SecretKey;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
+@Component
 public class TokenProviderImpl implements TokenProvider {
     @Value("${jwt.secret}")
     private String secret;
@@ -27,5 +32,35 @@ public class TokenProviderImpl implements TokenProvider {
                 .setExpiration(Date.from(Instant.now().plusSeconds(expiration)))
                 .signWith(key)
                 .compact();
+    }
+
+    @Override
+    public String extractToken(ServerRequest request) {
+        String headerVal = request.headers().firstHeader("ACTIVE-TOKEN");
+        assert headerVal != null;
+        if(!headerVal.startsWith("Bearer") || headerVal.isBlank())
+            throw new QueueException(QueueErrorCode.INVALID_TOKEN);
+
+        return headerVal;
+    }
+
+    @Override
+    public boolean validateToken(String token, UUID userId, UUID auctionId) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secret));
+        UUID userIdPayload = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId", UUID.class);
+
+        UUID auctionIdPayload = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("auctionId", UUID.class);
+
+        return userId.equals(userIdPayload) && auctionId.equals(auctionIdPayload);
     }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -61,7 +61,7 @@ public class RedisRepositoryImpl implements RedisRepository {
     public Flux<UUID> getAllActiveAuctions() {
         return redisOps.opsForSet()
                 .members(GLOBAL_ACTIVE_AUCTIONS_KEY)
-                .cast(UUID.class);
+                .map(uuid -> UUID.fromString((String) uuid));
     }
 
     public Mono<Long> removeActiveAuction(UUID auctionId) {

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -118,4 +118,10 @@ public class RedisRepositoryImpl implements RedisRepository {
     public Mono<Long> getRank(String waitingKey, UUID userId) {
         return redisOps.opsForZSet().rank(waitingKey, userId);
     }
+
+    @Override
+    public Mono<Boolean> saveToken(String tokenKey, Map<UUID, String> tokens) {
+        return redisOps.opsForHash()
+                .putAll(tokenKey, tokens);
+    }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -29,25 +29,6 @@ public class RedisRepositoryImpl implements RedisRepository {
     private final ObjectMapper objectMapper;
 
     @Override
-    public Mono<Object> getValue(String key) {
-        return redisOps.opsForValue()
-                .get(key)
-                .map(String::valueOf);
-    }
-
-    @Override
-    public Mono<Boolean> setValue(String key, Object value) {
-        return redisOps.opsForValue()
-                .set(key, value);
-    }
-
-    @Override
-    public Mono<Boolean> deleteValue(String key) {
-        return redisOps.opsForValue()
-                .delete(key);
-    }
-
-    @Override
     public Mono<Boolean> saveConfig(String configKey, QueueConfigModel model) {
         Map<String, String> configMap = model.toMap();
 
@@ -58,6 +39,12 @@ public class RedisRepositoryImpl implements RedisRepository {
     @Override
     public Mono<Boolean> setConfigExpiration(String key, Instant expireAt) {
         return redisOps.expireAt(key, expireAt);
+    }
+
+    @Override
+    public Mono<Boolean> deleteConfig(String configKey) {
+        return redisOps.opsForHash()
+                .delete(configKey);
     }
 
     @Override

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -1,32 +1,29 @@
 package com.bidket.queue.infrastructure.redis;
 
-import com.bidket.queue.domain.exception.QueueException;
 import com.bidket.queue.domain.model.QueueConfigModel;
-import com.bidket.queue.domain.model.QueueErrorCode;
 import com.bidket.queue.domain.repository.RedisRepository;
-import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
-import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
-import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAmount;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class RedisRepositoryImpl implements RedisRepository {
     private final ReactiveRedisOperations<String, Object> redisOps;
     private final ObjectMapper objectMapper;
+
+    private static final String GLOBAL_ACTIVE_AUCTIONS_KEY = "global:active_auctions";
 
     @Override
     public Mono<Boolean> saveConfig(String configKey, QueueConfigModel model) {
@@ -46,7 +43,7 @@ public class RedisRepositoryImpl implements RedisRepository {
     }
 
     @Override
-    public Mono<Boolean> setConfigExpiration(String key, Instant expireAt) {
+    public Mono<Boolean> setExpiration(String key, Instant expireAt) {
         return redisOps.expireAt(key, expireAt);
     }
 
@@ -56,22 +53,65 @@ public class RedisRepositoryImpl implements RedisRepository {
                 .delete(configKey);
     }
 
+    public Mono<Long> registerActiveAuction(UUID auctionId) {
+        return redisOps.opsForSet()
+                .add(GLOBAL_ACTIVE_AUCTIONS_KEY, auctionId);
+    }
+
+    public Flux<UUID> getAllActiveAuctions() {
+        return redisOps.opsForSet()
+                .members(GLOBAL_ACTIVE_AUCTIONS_KEY)
+                .cast(UUID.class);
+    }
+
+    public Mono<Long> removeActiveAuction(UUID auctionId) {
+        return redisOps.opsForSet()
+                .remove(GLOBAL_ACTIVE_AUCTIONS_KEY, auctionId);
+    }
+
     @Override
     public Mono<Boolean> addActiveUser(String activeKey, Long maxActive, UUID userId) {
         long now = System.currentTimeMillis();
         return redisOps.opsForZSet().size(activeKey)
                 .flatMap(currentSize -> {
-                    if(currentSize < maxActive)
+                    if (currentSize < maxActive)
                         return redisOps.opsForZSet().add(activeKey, userId, now);
 
                     return Mono.just(false);
                 });
     }
 
+    public Mono<Long> addAllActiveUser(String activeKey, List<UUID> userIds) {
+        if (userIds.isEmpty())
+            return Mono.just(0L);
+
+        long now = System.currentTimeMillis();
+
+        Set<ZSetOperations.TypedTuple<Object>> tuples = userIds.stream()
+                .map(id -> ZSetOperations.TypedTuple.of((Object) id.toString(), (double) now))
+                .collect(Collectors.toSet());
+
+        return redisOps.opsForZSet()
+                .addAll(activeKey, tuples);
+    }
+
+    public Mono<Long> activeUserCount(String activeKey) {
+        return redisOps.opsForZSet().size(activeKey);
+    }
+
     @Override
     public Mono<Boolean> addWaitingUser(String waitingKey, UUID userId) {
         long now = System.currentTimeMillis();
+        // TODO waiting queue 용량 제한
         return redisOps.opsForZSet().add(waitingKey, userId, now);
+    }
+
+    public Mono<List<UUID>> popUserIdWaitingQueue(String waitingKey, long limit) {
+        return redisOps.opsForZSet()
+                .popMin(waitingKey, limit)
+                .map(ZSetOperations.TypedTuple::getValue)
+                .map(uuid -> UUID.fromString((String) uuid))
+                .collectList();
     }
 
     @Override

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -6,14 +6,19 @@ import com.bidket.queue.domain.model.QueueErrorCode;
 import com.bidket.queue.domain.repository.RedisRepository;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
+import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Map;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -43,7 +48,7 @@ public class RedisRepositoryImpl implements RedisRepository {
     @Override
     public Mono<QueueCreateResponse> createQueueConfig(QueueCreateRequest request) {
         QueueConfigModel queueConfig = request.toModel();
-        String key = "auction:config:" + request.auctionId() + ":config";
+        String key = "queue:auction:" + request.auctionId() + ":config";
         Map<String, Object> configMap = queueConfig.toMap();
 
         return redisOps.opsForHash()
@@ -62,6 +67,55 @@ public class RedisRepositoryImpl implements RedisRepository {
                         return e;
 
                     return new QueueException(QueueErrorCode.REDIS_CONNECTION_ERROR);
+                });
+    }
+
+    @Override
+    public Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId) {
+        String configKey = "queue:auction:" + auctionId + ":config";
+        String activeKey = "queue:auction:" + auctionId + ":active";
+        String waitingKey = "queue:auction:" + auctionId + ":waiting";
+
+        long now = System.currentTimeMillis();
+
+        return redisOps.opsForValue().get(configKey)
+                .switchIfEmpty(Mono.error(new QueueException(QueueErrorCode.CONFIG_NOT_FOUND)))
+                .flatMap(configJson -> {
+                    return Mono.fromCallable(() -> objectMapper.readValue((JsonParser) configJson, QueueConfigModel.class))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .onErrorMap(e -> new QueueException(QueueErrorCode.AUCTION_CLOSED));
+                })
+                .flatMap(config -> {
+                    config.checkOpenStatus(Instant.now());
+
+                    return redisOps.opsForZSet().size(activeKey)
+                            .flatMap(currentSize -> {
+                                if (currentSize < config.getMaxActive()) {
+                                    return redisOps.opsForZSet().add(activeKey, userId, now)
+                                            .map(isSuccess -> {
+                                                return QueueEnterResponse.builder()
+                                                        .auctionId(auctionId)
+                                                        .userId(userId)
+                                                        .rank(0L)
+                                                        .retryAfter(0)
+                                                        .message("입장 성공")
+                                                        .build();
+                                            });
+                                } else {
+                                    return redisOps.opsForZSet().add(waitingKey, userId, now)
+                                            .flatMap(isSuccess -> redisOps.opsForZSet().rank(waitingKey, userId))
+                                            .map(rank -> {
+                                                return QueueEnterResponse.builder()
+                                                        .auctionId(auctionId)
+                                                        .userId(userId)
+                                                        .rank(rank)
+                                                        .retryAfter(3)
+                                                        .message("대기 중")
+                                                        .build();
+                                            });
+
+                                }
+                            });
                 });
     }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -57,55 +57,6 @@ public class RedisRepositoryImpl implements RedisRepository {
     }
 
     @Override
-    public Mono<QueueEnterResponse> enterQueue(UUID userId, UUID auctionId) {
-        String configKey = "queue:auction:" + auctionId + ":config";
-        String activeKey = "queue:auction:" + auctionId + ":active";
-        String waitingKey = "queue:auction:" + auctionId + ":waiting";
-
-        long now = System.currentTimeMillis();
-
-        return redisOps.opsForValue().get(configKey)
-                .switchIfEmpty(Mono.error(new QueueException(QueueErrorCode.CONFIG_NOT_FOUND)))
-                .flatMap(configJson -> {
-                    return Mono.fromCallable(() -> objectMapper.readValue((JsonParser) configJson, QueueConfigModel.class))
-                            .subscribeOn(Schedulers.boundedElastic())
-                            .onErrorMap(e -> new QueueException(QueueErrorCode.AUCTION_CLOSED));
-                })
-                .flatMap(config -> {
-                    config.checkOpenStatus(Instant.now());
-
-                    return redisOps.opsForZSet().size(activeKey)
-                            .flatMap(currentSize -> {
-                                if (currentSize < config.getMaxActive()) {
-                                    return redisOps.opsForZSet().add(activeKey, userId, now)
-                                            .map(isSuccess -> {
-                                                return QueueEnterResponse.builder()
-                                                        .auctionId(auctionId)
-                                                        .userId(userId)
-                                                        .rank(0L)
-                                                        .retryAfter(0)
-                                                        .message("입장 성공")
-                                                        .build();
-                                            });
-                                } else {
-                                    return redisOps.opsForZSet().add(waitingKey, userId, now)
-                                            .flatMap(isSuccess -> redisOps.opsForZSet().rank(waitingKey, userId))
-                                            .map(rank -> {
-                                                return QueueEnterResponse.builder()
-                                                        .auctionId(auctionId)
-                                                        .userId(userId)
-                                                        .rank(rank)
-                                                        .retryAfter(3)
-                                                        .message("대기 중")
-                                                        .build();
-                                            });
-
-                                }
-                            });
-                });
-    }
-
-    @Override
     public Mono<Boolean> addActiveUser(String activeKey, Long maxActive, UUID userId) {
         long now = System.currentTimeMillis();
         return redisOps.opsForZSet().size(activeKey)

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/redis/RedisRepositoryImpl.java
@@ -1,9 +1,9 @@
-package com.bidket.queue.domain.repository;
+package com.bidket.queue.infrastructure.redis;
 
 import com.bidket.queue.domain.exception.QueueException;
 import com.bidket.queue.domain.model.QueueConfigModel;
 import com.bidket.queue.domain.model.QueueErrorCode;
-import com.bidket.queue.infrastructure.redis.RedisRepository;
+import com.bidket.queue.domain.repository.RedisRepository;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/schedule/QueueScheduler.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/schedule/QueueScheduler.java
@@ -22,13 +22,14 @@ public class QueueScheduler {
 
     @Scheduled(fixedDelay = 1000)
     public void entranceSchedule() {
+        log.info("스케줄링 시작");
         redisRepository.getAllActiveAuctions()
                 .parallel()
                 .runOn(Schedulers.boundedElastic())
                 .flatMap(this::processAuction)
                 .subscribe(
                         null,
-                        error -> log.error("대기열 입장 스케줄러 에러")
+                        e -> log.error("대기열 입장 스케줄러 에러", e)
                 );
     }
 
@@ -60,7 +61,7 @@ public class QueueScheduler {
                                                 });
 
                                                 log.info("경매[{}] {} 명 입장", auctionId, userIds.size());
-                                                return redisRepository.addAllActiveUser(waitingKey, userIds)
+                                                return redisRepository.addAllActiveUser(activeKey, userIds)
                                                         .flatMap(added -> {
                                                             String tokenKey = "queue:token:" + auctionId;
                                                             return redisRepository.saveToken(tokenKey, userTokens);

--- a/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/schedule/QueueScheduler.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/infrastructure/schedule/QueueScheduler.java
@@ -1,0 +1,68 @@
+package com.bidket.queue.infrastructure.schedule;
+
+import com.bidket.queue.domain.repository.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueScheduler {
+    private final RedisRepository redisRepository;
+
+    @Scheduled(fixedDelay = 1000)
+    public void entranceSchedule() {
+        redisRepository.getAllActiveAuctions()
+                .parallel()
+                .runOn(Schedulers.boundedElastic())
+                .flatMap(this::processAuction)
+                .subscribe(
+                        null,
+                        error -> log.error("대기열 입장 스케줄러 에러")
+                );
+    }
+
+    private Mono<Void> processAuction(UUID auctionId) {
+        String configKey = "queue:auction:" + auctionId + ":config";
+        String activeKey = "queue:auction:" + auctionId + ":active";
+        String waitingKey = "queue:auction:" + auctionId + ":waiting";
+
+        return redisRepository.getConfig(configKey)
+                .flatMap(config ->
+                        redisRepository.activeUserCount(activeKey)
+                                .flatMap(currentActive -> {
+                                    long maxUser = config.getMaxActive();
+                                    long availableSlots = maxUser - currentActive;
+                                    long limit = Math.min(availableSlots, config.getPermitsPerSec());
+
+                                    if (limit <= 0)
+                                        return Mono.empty();
+
+                                    return redisRepository.popUserIdWaitingQueue(waitingKey, limit)
+                                            .flatMap(users -> {
+                                                if (users.isEmpty())
+                                                    return Mono.empty();
+
+                                                log.info("경매[{}] {} 명 입장", auctionId, users.size());
+
+                                                return redisRepository.addAllActiveUser(waitingKey, users);
+                                            });
+
+                                })
+
+                )
+                .switchIfEmpty(Mono.defer(() -> {
+                    log.warn("경매[{}] 설정 만료", auctionId);
+                    log.debug("경매[{}] 관리 목록에서 제거", auctionId);
+
+                    return redisRepository.removeActiveAuction(auctionId);
+                }))
+                .then();
+    }
+}

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/api/QueueController.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/api/QueueController.java
@@ -4,16 +4,17 @@ import com.bidket.common.presentation.response.ApiResponse;
 import com.bidket.queue.application.service.QueueService;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
+import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.server.ServerRequest;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
+import java.util.Objects;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/v1")
@@ -27,5 +28,20 @@ public class QueueController {
                 .map(response -> ResponseEntity
                         .created(URI.create("/v1/internal/queues/" + response.auctionId()))
                         .body(ApiResponse.success("queue config 생성", response)));
+    }
+
+    @PostMapping("/queues/{auctionId}")
+    public Mono<ResponseEntity<ApiResponse<QueueEnterResponse>>> enterQueue(@PathVariable UUID auctionId, ServerRequest request) {
+        // TODO userId 전달 방식 확립 이후 변경
+        // UUID userId = UUID.fromString(Objects.requireNonNull(request.headers().firstHeader("USER-ID")));
+        UUID userId = UUID.randomUUID();
+        return queueService.enterQueue(userId, auctionId)
+                .map(response -> {
+                    ResponseEntity<ApiResponse<QueueEnterResponse>> responseEntity = ResponseEntity.ok(ApiResponse.success(response));
+                    if(response.token() != null)
+                        responseEntity.getHeaders().add("X-ACTIVE-TOKEN", response.token());
+
+                    return responseEntity;
+                });
     }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/api/QueueController.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/api/QueueController.java
@@ -13,7 +13,6 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
-import java.util.Objects;
 import java.util.UUID;
 
 @RestController
@@ -31,17 +30,13 @@ public class QueueController {
     }
 
     @PostMapping("/queues/{auctionId}")
-    public Mono<ResponseEntity<ApiResponse<QueueEnterResponse>>> enterQueue(@PathVariable UUID auctionId, ServerRequest request) {
+    public Mono<ResponseEntity<ApiResponse<QueueEnterResponse>>> enterQueue(@PathVariable UUID auctionId) {
         // TODO userId 전달 방식 확립 이후 변경
         // UUID userId = UUID.fromString(Objects.requireNonNull(request.headers().firstHeader("USER-ID")));
         UUID userId = UUID.randomUUID();
         return queueService.enterQueue(userId, auctionId)
-                .map(response -> {
-                    ResponseEntity<ApiResponse<QueueEnterResponse>> responseEntity = ResponseEntity.ok(ApiResponse.success(response));
-                    if(response.token() != null)
-                        responseEntity.getHeaders().add("X-ACTIVE-TOKEN", response.token());
-
-                    return responseEntity;
-                });
+                .map(response ->
+                        ResponseEntity.ok(ApiResponse.success(response))
+                );
     }
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/api/QueueController.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/api/QueueController.java
@@ -23,7 +23,7 @@ public class QueueController {
 
     @PostMapping("/internal/queues")
     public Mono<ResponseEntity<ApiResponse<QueueCreateResponse>>> createQueueConfig(@RequestBody @Valid QueueCreateRequest request) {
-        return queueService.createQueue(request)
+        return queueService.createConfigQueue(request)
                 .map(response -> ResponseEntity
                         .created(URI.create("/v1/internal/queues/" + response.auctionId()))
                         .body(ApiResponse.success("queue config 생성", response)));

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/request/QueueCreateRequest.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/request/QueueCreateRequest.java
@@ -4,6 +4,7 @@ import com.bidket.queue.domain.model.QueueConfigModel;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -12,8 +13,8 @@ public record QueueCreateRequest(
         @NotNull UUID auctionId,
         @NotNull Long maxActive,
         @NotNull Integer permitsPerSec,
-        @NotNull LocalDateTime openAt,
-        @NotNull LocalDateTime closeAt
+        @NotNull Instant openAt,
+        @NotNull Instant closeAt
 ) {
     public QueueConfigModel toModel() {
         return QueueConfigModel.builder()

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/response/QueueCreateResponse.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/response/QueueCreateResponse.java
@@ -2,7 +2,7 @@ package com.bidket.queue.presentation.dto.response;
 
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Builder
@@ -10,7 +10,7 @@ public record QueueCreateResponse(
         UUID auctionId,
         Long maxActive,
         Integer permitsPerSec,
-        LocalDateTime openAt,
-        LocalDateTime closeAt
+        Instant openAt,
+        Instant closeAt
 ) {
 }

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/response/QueueEnterResponse.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/response/QueueEnterResponse.java
@@ -1,0 +1,15 @@
+package com.bidket.queue.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record QueueEnterResponse(
+        UUID auctionId,
+        UUID userId,
+        Long rank,
+        Integer retryAfter,
+        String message
+) {
+}

--- a/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/response/QueueEnterResponse.java
+++ b/backend/queue-service/src/main/java/com/bidket/queue/presentation/dto/response/QueueEnterResponse.java
@@ -1,5 +1,6 @@
 package com.bidket.queue.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 
 import java.util.UUID;
@@ -10,6 +11,8 @@ public record QueueEnterResponse(
         UUID userId,
         Long rank,
         Integer retryAfter,
-        String message
+        String message,
+        @JsonIgnore
+        String token
 ) {
 }

--- a/backend/queue-service/src/main/resources/application-test.yml
+++ b/backend/queue-service/src/main/resources/application-test.yml
@@ -8,9 +8,9 @@ spring:
     import: optional:file:.env[.properties]
 
   datasource:
-    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${USER_DB}
-    username: ${POSTGRES_USER}
-    password: ${POSTGRES_PASSWORD}
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
 
   jpa:
     hibernate:
@@ -31,4 +31,4 @@ eureka:
 
 jwt:
   secret: ${JWT_SECRET}
-  expire: ${JWT_EXPIRED_AT}
+  expired_at: ${JWT_EXPIRED_AT}

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -31,4 +31,4 @@ eureka:
 
 jwt:
   secret: ${JWT_SECRET}
-  expire: ${JWT_EXPIRED_AT}
+  expiration: ${JWT_EXPIRATION}

--- a/backend/queue-service/src/test/java/com/bidket/queue/IntegralTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/IntegralTest.java
@@ -14,7 +14,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 @SpringBootTest
@@ -33,8 +35,8 @@ public class IntegralTest {
                 .auctionId(UUID.randomUUID())
                 .maxActive(100L)
                 .permitsPerSec(1)
-                .openAt(LocalDateTime.now())
-                .closeAt(LocalDateTime.now().plusHours(5L))
+                .openAt(Instant.now())
+                .closeAt(Instant.now().plus(2, ChronoUnit.HOURS))
                 .build();
 
         ResponseEntity<ApiResponse<QueueCreateResponse>> response = queueController.createQueueConfig(request).block();

--- a/backend/queue-service/src/test/java/com/bidket/queue/IntegralTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/IntegralTest.java
@@ -12,11 +12,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class IntegralTest {
 
     private static final Logger log = LoggerFactory.getLogger(IntegralTest.class);

--- a/backend/queue-service/src/test/java/com/bidket/queue/IntegralTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/IntegralTest.java
@@ -4,6 +4,7 @@ import com.bidket.common.presentation.response.ApiResponse;
 import com.bidket.queue.presentation.api.QueueController;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
+import com.bidket.queue.presentation.dto.response.QueueEnterResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import reactor.core.publisher.Mono;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -43,6 +45,17 @@ public class IntegralTest {
 
         String key = "auction:config:" + request.auctionId() + ":config";
 
-        log.info("response: \n" + mapper.writeValueAsString(response));
+        log.info("response: \n {}", mapper.writeValueAsString(response));
+    }
+
+    @Test
+    void enterQueue() throws JsonProcessingException {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID auctionId = UUID.fromString("46867f96-661d-4e7a-a613-1e57c3645704");
+
+        ResponseEntity<ApiResponse<QueueEnterResponse>> response = queueController.enterQueue(auctionId).block();
+
+        log.info("response: \n {}", mapper.writeValueAsString(response));
     }
 }

--- a/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
@@ -53,12 +53,12 @@ public class UnitTest {
                 .closeAt(Instant.now().plus(1, ChronoUnit.DAYS))
                 .build();
 
-        doReturn(hashOps).when(redisOps).opsForHash();
-
-        when(hashOps.putAll(any(String.class), any()))
+        when(redisRepository.saveConfig(any(String.class), any(QueueConfigModel.class)))
                 .thenReturn(Mono.just(true));
-        when(redisOps.expireAt(any(String.class), any(Instant.class)))
+        when(redisRepository.setExpiration(any(String.class), any(Instant.class)))
                 .thenReturn(Mono.just(true));
+        when(redisRepository.registerActiveAuction(any(UUID.class)))
+                .thenReturn(Mono.just(1L));
 
         // when
         Mono<QueueCreateResponse> response = queueService.createConfigQueue(request);
@@ -83,10 +83,9 @@ public class UnitTest {
                 .closeAt(Instant.now().plus(1, ChronoUnit.DAYS))
                 .build();
 
-        doReturn(hashOps).when(redisOps).opsForHash();
-
-        when(hashOps.putAll(any(String.class), any()))
+        when(redisRepository.saveConfig(any(String.class), any(QueueConfigModel.class)))
                 .thenReturn(Mono.just(false));
+
 
         Mono<QueueCreateResponse> response = queueService.createConfigQueue(request);
 
@@ -110,11 +109,9 @@ public class UnitTest {
                 .closeAt(Instant.now().plus(1, ChronoUnit.DAYS))
                 .build();
 
-        doReturn(hashOps).when(redisOps).opsForHash();
-
-        when(hashOps.putAll(any(String.class), any()))
+        when(redisRepository.saveConfig(any(String.class), any(QueueConfigModel.class)))
                 .thenReturn(Mono.just(true));
-        when(redisOps.expireAt(any(String.class), any()))
+        when(redisRepository.setExpiration(any(String.class), any(Instant.class)))
                 .thenReturn(Mono.just(false));
 
         Mono<QueueCreateResponse> response = queueService.createConfigQueue(request);

--- a/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
@@ -149,8 +149,10 @@ public class UnitTest {
         when(redisRepository.getRank(any(String.class), any()))
                 .thenReturn(Mono.just(100L));
 
+        // when
         Mono<QueueEnterResponse> response = queueService.enterQueue(userId, auctionId);
 
+        // then
         StepVerifier.create(response)
                 .expectNextMatches(result ->
                         result.token() == null &&

--- a/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
@@ -1,5 +1,6 @@
 package com.bidket.queue;
 
+import com.bidket.queue.application.service.QueueService;
 import com.bidket.queue.domain.exception.QueueException;
 import com.bidket.queue.domain.model.QueueErrorCode;
 import com.bidket.queue.infrastructure.redis.RedisRepositoryImpl;
@@ -18,6 +19,7 @@ import reactor.test.StepVerifier;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,6 +30,8 @@ import static org.mockito.Mockito.when;
 public class UnitTest {
     @InjectMocks
     private RedisRepositoryImpl redisRepository;
+    @InjectMocks
+    private QueueService queueService;
 
     @Mock
     private ReactiveRedisOperations<String, Object> redisOps;
@@ -43,8 +47,8 @@ public class UnitTest {
                 .auctionId(UUID.randomUUID())
                 .maxActive(100L)
                 .permitsPerSec(1)
-                .openAt(LocalDateTime.now())
-                .closeAt(LocalDateTime.now().plusHours(5L))
+                .openAt(Instant.now())
+                .closeAt(Instant.now().plus(1, ChronoUnit.DAYS))
                 .build();
 
         doReturn(hashOps).when(redisOps).opsForHash();
@@ -55,7 +59,7 @@ public class UnitTest {
                 .thenReturn(Mono.just(true));
 
         // when
-        Mono<QueueCreateResponse> response = redisRepository.createQueueConfig(request);
+        Mono<QueueCreateResponse> response = queueService.createConfigQueue(request);
 
         StepVerifier.create(response)
                 .expectNextMatches(result ->
@@ -73,8 +77,8 @@ public class UnitTest {
                 .auctionId(UUID.randomUUID())
                 .maxActive(100L)
                 .permitsPerSec(1)
-                .openAt(LocalDateTime.now())
-                .closeAt(LocalDateTime.now().plusHours(5L))
+                .openAt(Instant.now())
+                .closeAt(Instant.now().plus(1, ChronoUnit.DAYS))
                 .build();
 
         doReturn(hashOps).when(redisOps).opsForHash();
@@ -82,7 +86,7 @@ public class UnitTest {
         when(hashOps.putAll(any(String.class), any()))
                 .thenReturn(Mono.just(false));
 
-        Mono<QueueCreateResponse> response = redisRepository.createQueueConfig(request);
+        Mono<QueueCreateResponse> response = queueService.createConfigQueue(request);
 
         StepVerifier.create(response)
                 .expectErrorMatches(throwable ->
@@ -100,8 +104,8 @@ public class UnitTest {
                 .auctionId(UUID.randomUUID())
                 .maxActive(100L)
                 .permitsPerSec(1)
-                .openAt(LocalDateTime.now())
-                .closeAt(LocalDateTime.now().plusHours(5L))
+                .openAt(Instant.now())
+                .closeAt(Instant.now().plus(1, ChronoUnit.DAYS))
                 .build();
 
         doReturn(hashOps).when(redisOps).opsForHash();
@@ -111,7 +115,7 @@ public class UnitTest {
         when(redisOps.expireAt(any(String.class), any()))
                 .thenReturn(Mono.just(false));
 
-        Mono<QueueCreateResponse> response = redisRepository.createQueueConfig(request);
+        Mono<QueueCreateResponse> response = queueService.createConfigQueue(request);
 
         StepVerifier.create(response)
                 .expectErrorMatches(throwable ->
@@ -119,5 +123,11 @@ public class UnitTest {
                                 ((QueueException) throwable).getErrorCode() == QueueErrorCode.REDIS_EXPIRE_SET_FAILED
                 )
                 .verify();
+    }
+
+    @Test
+    @DisplayName("성공: 대기열 입장 성공")
+    void enterQueue_Enter_Success() {
+
     }
 }

--- a/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
+++ b/backend/queue-service/src/test/java/com/bidket/queue/UnitTest.java
@@ -2,7 +2,7 @@ package com.bidket.queue;
 
 import com.bidket.queue.domain.exception.QueueException;
 import com.bidket.queue.domain.model.QueueErrorCode;
-import com.bidket.queue.domain.repository.RedisRepositoryImpl;
+import com.bidket.queue.infrastructure.redis.RedisRepositoryImpl;
 import com.bidket.queue.presentation.dto.request.QueueCreateRequest;
 import com.bidket.queue.presentation.dto.response.QueueCreateResponse;
 import org.junit.jupiter.api.DisplayName;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,25 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - EUREKA_SERVER_URL=http://eureka-server:8761/eureka
+      # Postgresql
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+
+      # Eureka & Gateway
+      - EUREKA_SERVER_URL=${EUREKA_SERVER_URL}
+      - EUREKA_PORT=8761
+      - GATEWAY_PORT=8000
+
+      # DB
+      - USER_DB=bidket_user
+      - QUEUE_DB=${QUEUE_DB}
+      - ORDER_DB=bidket_order
+      - NOTIFICATION_DB=bidket_notification
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRED_AT=${JWT_EXPIRED_AT}
+
     networks:
       - bidket-net
 


### PR DESCRIPTION
## Issue Number
- closed #5 

## Description
- 대기열 입장 기능 구현
- 대기열 입장 플로우
  1. POST `/v1/queues/{auctionId}` 진입
  2. queueConfig를 기반으로 경매 오픈 상태 확인
  3. 사용자 대기열 입장
  4. Scheduler가 1초에 한번씩 대기열에서 active queue로 사용자 이동
## Test Result
<img width="527" height="748" alt="image" src="https://github.com/user-attachments/assets/f05fa7ad-2395-4df3-b6a9-1b548f95c882" />

<img width="792" height="403" alt="image" src="https://github.com/user-attachments/assets/253612e8-a1d1-458e-93b7-ec0320128718" />

## To Reviewer
- QueueScheduler
- TokenProvider
- QueueService

코드를 여러번 엎어서 제대로 짠건지 잘 모르겠네요 아무튼 굴러긴합니다..ㅋㅋㅋ