### PR TITLE
Feature/order create

### DIFF
--- a/backend/order-service/build.gradle
+++ b/backend/order-service/build.gradle
@@ -15,7 +15,8 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+    runtimeOnly 'org.postgresql:postgresql'
     implementation 'com.github.Bidket:bidket-common-repo:main-SNAPSHOT'
 }

--- a/backend/order-service/src/main/java/com/bidket/order/application/facade/OrderFacade.java
+++ b/backend/order-service/src/main/java/com/bidket/order/application/facade/OrderFacade.java
@@ -1,0 +1,44 @@
+package com.bidket.order.application.facade;
+
+import com.bidket.order.application.info.OrderInfo;
+import com.bidket.order.domain.model.Order;
+import com.bidket.order.domain.repository.OrderRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderFacade {
+
+    private final OrderRepository orderRepository;
+    // TODO 포인트/경매/재고 검증용 Port 추가
+
+    @Transactional
+    public OrderInfo createOrder(UUID memberId,
+            UUID auctionId,
+            UUID shoeId,
+            Long amount,
+            Long usedPointAmount) {
+        // TODO 포인트 잔액 검증, 경매 낙찰 여부/유효 시간 검증, 재고 검증 추가
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime paymentExpiredAt = now.plusMinutes(15);
+
+        Order order = Order.createForPayment(
+                memberId,
+                auctionId,
+                shoeId,
+                amount,
+                usedPointAmount,
+                paymentExpiredAt,
+                now
+        );
+
+        Order saved = orderRepository.save(order);
+
+        return OrderInfo.from(saved);
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/application/info/OrderInfo.java
+++ b/backend/order-service/src/main/java/com/bidket/order/application/info/OrderInfo.java
@@ -1,0 +1,59 @@
+package com.bidket.order.application.info;
+
+import com.bidket.order.domain.model.Order;
+import com.bidket.order.domain.model.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class OrderInfo {
+
+    private final UUID orderId;
+    private final UUID userId;
+    private final UUID auctionId;
+    private final UUID shoeId;
+    private final OrderStatus status;
+    private final Long amount;
+    private final Long usedPointAmount;
+    private final LocalDateTime paymentExpiredAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public OrderInfo(UUID orderId,
+            UUID userId,
+            UUID auctionId,
+            UUID shoeId,
+            OrderStatus status,
+            Long amount,
+            Long usedPointAmount,
+            LocalDateTime paymentExpiredAt,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt) {
+        this.orderId = orderId;
+        this.userId = userId;
+        this.auctionId = auctionId;
+        this.shoeId = shoeId;
+        this.status = status;
+        this.amount = amount;
+        this.usedPointAmount = usedPointAmount;
+        this.paymentExpiredAt = paymentExpiredAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static OrderInfo from(Order order) {
+        return new OrderInfo(
+                order.getId(),
+                order.getUserId(),
+                order.getAuctionId(),
+                order.getShoeId(),
+                order.getStatus(),
+                order.getAmount(),
+                order.getUsedPointAmount(),
+                order.getPaymentExpiredAt(),
+                order.getCreatedAt(),
+                order.getUpdatedAt()
+        );
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/domain/model/Order.java
+++ b/backend/order-service/src/main/java/com/bidket/order/domain/model/Order.java
@@ -1,0 +1,101 @@
+package com.bidket.order.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class Order {
+
+    private final UUID id;
+    private final UUID userId;
+    private final UUID auctionId;
+    private final UUID shoeId;
+    private final OrderStatus status;
+    private final Long amount;
+    private final Long usedPointAmount;
+    private final LocalDateTime paymentExpiredAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    private Order(UUID id,
+            UUID userId,
+            UUID auctionId,
+            UUID shoeId,
+            OrderStatus status,
+            Long amount,
+            Long usedPointAmount,
+            LocalDateTime paymentExpiredAt,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.auctionId = auctionId;
+        this.shoeId = shoeId;
+        this.status = status;
+        this.amount = amount;
+        this.usedPointAmount = usedPointAmount;
+        this.paymentExpiredAt = paymentExpiredAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static Order createForPayment(UUID userId,
+            UUID auctionId,
+            UUID shoeId,
+            Long amount,
+            Long usedPointAmount,
+            LocalDateTime paymentExpiredAt,
+            LocalDateTime now) {
+
+        Long safeUsedPoint = usedPointAmount == null ? 0L : usedPointAmount;
+
+        if (amount == null || amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        if (safeUsedPoint < 0) {
+            throw new IllegalArgumentException("usedPointAmount must be >= 0");
+        }
+        if (safeUsedPoint > amount) {
+            throw new IllegalArgumentException("usedPointAmount cannot be greater than amount");
+        }
+
+        return new Order(
+                null,
+                userId,
+                auctionId,
+                shoeId,
+                OrderStatus.PAYMENT,
+                amount,
+                safeUsedPoint,
+                paymentExpiredAt,
+                now,
+                now
+        );
+    }
+
+    public static Order of(UUID id,
+            UUID userId,
+            UUID auctionId,
+            UUID shoeId,
+            OrderStatus status,
+            Long amount,
+            Long usedPointAmount,
+            LocalDateTime paymentExpiredAt,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt) {
+
+        return new Order(
+                id,
+                userId,
+                auctionId,
+                shoeId,
+                status,
+                amount,
+                usedPointAmount,
+                paymentExpiredAt,
+                createdAt,
+                updatedAt
+        );
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/domain/model/OrderStatus.java
+++ b/backend/order-service/src/main/java/com/bidket/order/domain/model/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.bidket.order.domain.model;
+
+public enum OrderStatus {
+    PAYMENT,    // 결제 대기
+    PAID,       // 결제 완료
+    CANCELED,   // 주문 취소
+    EXPIRED     // 결제 만료
+}

--- a/backend/order-service/src/main/java/com/bidket/order/domain/repository/OrderRepository.java
+++ b/backend/order-service/src/main/java/com/bidket/order/domain/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.bidket.order.domain.repository;
+
+import com.bidket.order.domain.model.Order;
+
+public interface OrderRepository {
+
+    Order save(Order order);
+}

--- a/backend/order-service/src/main/java/com/bidket/order/global/config/JpaAuditingConfig.java
+++ b/backend/order-service/src/main/java/com/bidket/order/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.bidket.order.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/backend/order-service/src/main/java/com/bidket/order/infrastructure/persistence/entity/OrderEntity.java
+++ b/backend/order-service/src/main/java/com/bidket/order/infrastructure/persistence/entity/OrderEntity.java
@@ -1,0 +1,115 @@
+package com.bidket.order.infrastructure.persistence.entity;
+
+import com.bidket.common.infra.BaseEntity;
+import com.bidket.order.domain.model.OrderStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_order")
+public class OrderEntity extends BaseEntity {
+
+    @Id
+    @Column(name = "order_id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private UUID auctionId;
+
+    @Column(nullable = false)
+    private UUID shoeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(nullable = false)
+    private Long usedPointAmount;
+
+    @Column(nullable = false)
+    private LocalDateTime paymentExpiredAt;
+
+    protected OrderEntity() {
+    }
+
+    private OrderEntity(UUID userId,
+            UUID auctionId,
+            UUID shoeId,
+            OrderStatus status,
+            Long amount,
+            Long usedPointAmount,
+            LocalDateTime paymentExpiredAt) {
+        this.userId = userId;
+        this.auctionId = auctionId;
+        this.shoeId = shoeId;
+        this.status = status;
+        this.amount = amount;
+        this.usedPointAmount = usedPointAmount;
+        this.paymentExpiredAt = paymentExpiredAt;
+    }
+
+    public static OrderEntity create(UUID userId,
+            UUID auctionId,
+            UUID shoeId,
+            OrderStatus status,
+            Long amount,
+            Long usedPointAmount,
+            LocalDateTime paymentExpiredAt) {
+        return new OrderEntity(
+                userId,
+                auctionId,
+                shoeId,
+                status,
+                amount,
+                usedPointAmount,
+                paymentExpiredAt
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public UUID getAuctionId() {
+        return auctionId;
+    }
+
+    public UUID getShoeId() {
+        return shoeId;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public Long getUsedPointAmount() {
+        return usedPointAmount;
+    }
+
+    public LocalDateTime getPaymentExpiredAt() {
+        return paymentExpiredAt;
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/infrastructure/persistence/impl/OrderRepositoryImpl.java
+++ b/backend/order-service/src/main/java/com/bidket/order/infrastructure/persistence/impl/OrderRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.bidket.order.infrastructure.persistence.impl;
+
+import com.bidket.order.domain.model.Order;
+import com.bidket.order.domain.repository.OrderRepository;
+import com.bidket.order.infrastructure.persistence.entity.OrderEntity;
+import com.bidket.order.infrastructure.persistence.repository.OrderJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+
+    private final OrderJpaRepository orderJpaRepository;
+
+    @Override
+    public Order save(Order order) {
+        OrderEntity entity = toEntity(order);
+        OrderEntity saved = orderJpaRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    private OrderEntity toEntity(Order order) {
+        return OrderEntity.create(
+                order.getUserId(),
+                order.getAuctionId(),
+                order.getShoeId(),
+                order.getStatus(),
+                order.getAmount(),
+                order.getUsedPointAmount(),
+                order.getPaymentExpiredAt()
+        );
+    }
+
+    private Order toDomain(OrderEntity entity) {
+        return Order.of(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getAuctionId(),
+                entity.getShoeId(),
+                entity.getStatus(),
+                entity.getAmount(),
+                entity.getUsedPointAmount(),
+                entity.getPaymentExpiredAt(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/infrastructure/persistence/repository/OrderJpaRepository.java
+++ b/backend/order-service/src/main/java/com/bidket/order/infrastructure/persistence/repository/OrderJpaRepository.java
@@ -1,0 +1,9 @@
+package com.bidket.order.infrastructure.persistence.repository;
+
+import com.bidket.order.infrastructure.persistence.entity.OrderEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID> {
+
+}

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/api/OrderController.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/api/OrderController.java
@@ -1,0 +1,65 @@
+package com.bidket.order.presentation.api;
+
+import com.bidket.common.presentation.response.ApiResponse;
+import com.bidket.order.application.facade.OrderFacade;
+import com.bidket.order.application.info.OrderInfo;
+import com.bidket.order.presentation.dto.request.OrderCreateRequest;
+import com.bidket.order.presentation.dto.response.OrderCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/orders")
+@Tag(name = "Order", description = "신발 경매 주문 API")
+public class OrderController {
+
+    private final OrderFacade orderFacade;
+
+    @Operation(
+            summary = "신발 경매 주문 생성",
+            description = "낙찰된 신발 경매에 대해 주문을 생성하고 결제 대기 상태로 저장합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "주문 생성 성공",
+                    content = @Content(schema = @Schema(implementation = OrderCreateResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 요청"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "유효하지 않은 경매 상태 또는 이미 처리된 주문"
+            )
+    })
+    @PostMapping
+    public ApiResponse<OrderCreateResponse> createOrder(
+            @Valid @RequestBody OrderCreateRequest request
+    ) {
+        UUID userId = UUID.fromString(request.getUserId());
+
+        OrderInfo orderInfo = orderFacade.createOrder(
+                userId,
+                UUID.fromString(request.getAuctionId()),
+                UUID.fromString(request.getShoeId()),
+                request.getAmount(),
+                request.getUsePointAmount()
+        );
+
+        OrderCreateResponse response = OrderCreateResponse.from(orderInfo);
+        return ApiResponse.success("신발 경매 주문이 생성되었습니다.", response);
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/dto/request/OrderCreateRequest.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/dto/request/OrderCreateRequest.java
@@ -1,0 +1,33 @@
+package com.bidket.order.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "신발 경매 주문 생성 요청")
+public class OrderCreateRequest {
+
+    @NotNull
+    @Schema(description = "주문 요청 유저 ID", example = "11111111-2222-3333-4444-555555555555")
+    private String userId;
+
+    @NotBlank
+    @Schema(description = "경매 ID", example = "7c4d3f9a-1b2c-4d5e-9f01-23456789abcd")
+    private String auctionId;
+
+    @NotBlank
+    @Schema(description = "신발 ID", example = "b1a2c3d4-e5f6-7890-abcd-ef0123456789")
+    private String shoeId;
+
+    @Min(1)
+    @NotNull
+    @Schema(description = "주문 결제 금액(원)", example = "250000")
+    private Long amount;
+
+    @Min(0)
+    @Schema(description = "사용 포인트 금액(원)", example = "10000")
+    private Long usePointAmount;
+}

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/dto/response/OrderCreateResponse.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/dto/response/OrderCreateResponse.java
@@ -1,0 +1,82 @@
+package com.bidket.order.presentation.dto.response;
+
+import com.bidket.order.application.info.OrderInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "신발 경매 주문 생성 응답")
+public class OrderCreateResponse {
+
+    @Schema(description = "주문 ID", example = "a1b2c3d4-5678-90ab-cdef-1234567890ab")
+    private final String orderId;
+
+    @Schema(description = "회원 ID", example = "11111111-2222-3333-4444-555555555555")
+    private final String userId;
+
+    @Schema(description = "경매 ID", example = "7c4d3f9a-1b2c-4d5e-9f01-23456789abcd")
+    private final String auctionId;
+
+    @Schema(description = "신발 ID", example = "b1a2c3d4-e5f6-7890-abcd-ef0123456789")
+    private final String shoeId;
+
+    @Schema(description = "주문 상태", example = "PAYMENT")
+    private final String status;
+
+    @Schema(description = "주문 결제 금액(원)", example = "250000")
+    private final Long amount;
+
+    @Schema(description = "사용 포인트 금액(원)", example = "10000")
+    private final Long usedPointAmount;
+
+    @Schema(description = "결제 만료 시각", example = "2025-12-01T12:00:00")
+    private final String paymentExpiredAt;
+
+    @Schema(description = "주문 생성 시각", example = "2025-12-01T11:00:00")
+    private final String createdAt;
+
+    @Schema(description = "주문 수정 시각", example = "2025-12-01T11:00:00")
+    private final String updatedAt;
+
+    private OrderCreateResponse(
+            String orderId,
+            String userId,
+            String auctionId,
+            String shoeId,
+            String status,
+            Long amount,
+            Long usedPointAmount,
+            String paymentExpiredAt,
+            String createdAt,
+            String updatedAt
+    ) {
+        this.orderId = orderId;
+        this.userId = userId;
+        this.auctionId = auctionId;
+        this.shoeId = shoeId;
+        this.status = status;
+        this.amount = amount;
+        this.usedPointAmount = usedPointAmount;
+        this.paymentExpiredAt = paymentExpiredAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static OrderCreateResponse from(OrderInfo orderInfo) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+        return new OrderCreateResponse(
+                orderInfo.getOrderId().toString(),
+                orderInfo.getUserId().toString(),
+                orderInfo.getAuctionId().toString(),
+                orderInfo.getShoeId().toString(),
+                orderInfo.getStatus().name(),
+                orderInfo.getAmount(),
+                orderInfo.getUsedPointAmount(),
+                orderInfo.getPaymentExpiredAt().format(formatter),
+                orderInfo.getCreatedAt().format(formatter),
+                orderInfo.getUpdatedAt().format(formatter)
+        );
+    }
+}

--- a/backend/order-service/src/test/java/com/bidket/order/application/facade/OrderFacade.java
+++ b/backend/order-service/src/test/java/com/bidket/order/application/facade/OrderFacade.java
@@ -1,0 +1,88 @@
+package com.bidket.order.application.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bidket.order.application.info.OrderInfo;
+import com.bidket.order.domain.model.Order;
+import com.bidket.order.domain.repository.OrderRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderFacadeTest {
+
+    @InjectMocks
+    private OrderFacade orderFacade;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Test
+    @DisplayName("주문 생성 성공 - 주문 저장 후 생성 정보 반환")
+    void createOrder_success() {
+        // given
+        UUID userId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID auctionId = UUID.fromString("7c4d3f9a-1b2c-4d5e-9f01-23456789abcd");
+        UUID shoeId = UUID.fromString("b1a2c3d4-e5f6-7890-abcd-ef0123456789");
+        long amount = 250_000L;
+        long usedPointAmount = 10_000L;
+
+        // Facade 내부에서 Order.createForPayment(...)로 생성하고
+        // Repository.save(...) 결과를 기반으로 OrderInfo를 반환한다고 가정
+        Order savedOrder = org.mockito.Mockito.mock(Order.class);
+        given(orderRepository.save(any(Order.class))).willReturn(savedOrder);
+
+        // when
+        OrderInfo result = orderFacade.createOrder(
+                userId,
+                auctionId,
+                shoeId,
+                amount,
+                usedPointAmount
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        then(orderRepository)
+                .should()
+                .save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("주문 생성 실패 - 저장 과정에서 예외 발생 시 예외 전파")
+    void createOrder_fail_whenRepositoryThrows() {
+        // given
+        UUID userId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID auctionId = UUID.fromString("7c4d3f9a-1b2c-4d5e-9f01-23456789abcd");
+        UUID shoeId = UUID.fromString("b1a2c3d4-e5f6-7890-abcd-ef0123456789");
+        long amount = 250_000L;
+        long usedPointAmount = 10_000L;
+
+        given(orderRepository.save(any(Order.class)))
+                .willThrow(new RuntimeException("DB error"));
+
+        // when & then
+        assertThatThrownBy(() ->
+                orderFacade.createOrder(
+                        userId,
+                        auctionId,
+                        shoeId,
+                        amount,
+                        usedPointAmount
+                )
+        ).isInstanceOf(RuntimeException.class);
+
+        then(orderRepository)
+                .should()
+                .save(any(Order.class));
+    }
+}

--- a/backend/order-service/src/test/java/com/bidket/order/presentation/api/OrderController.java
+++ b/backend/order-service/src/test/java/com/bidket/order/presentation/api/OrderController.java
@@ -1,0 +1,134 @@
+package com.bidket.order.presentation.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bidket.order.application.facade.OrderFacade;
+import com.bidket.order.application.info.OrderInfo;
+import com.bidket.order.domain.model.OrderStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OrderController.class)
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OrderFacade orderFacade;
+
+    @Test
+    @DisplayName("주문 생성 성공 - 200 OK와 ApiResponse 반환")
+    void createOrder_success() throws Exception {
+        // given
+        String requestJson = """
+                {
+                  "userId": "11111111-2222-3333-4444-555555555555",
+                  "auctionId": "7c4d3f9a-1b2c-4d5e-9f01-23456789abcd",
+                  "shoeId": "b1a2c3d4-e5f6-7890-abcd-ef0123456789",
+                  "amount": 250000,
+                  "usePointAmount": 10000
+                }
+                """;
+
+        UUID orderId = UUID.fromString("d9a28926-8f22-49bb-8044-a51b83074e50");
+        UUID userId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID auctionId = UUID.fromString("7c4d3f9a-1b2c-4d5e-9f01-23456789abcd");
+        UUID shoeId = UUID.fromString("b1a2c3d4-e5f6-7890-abcd-ef0123456789");
+
+        long amount = 250000L;
+        long usedPointAmount = 10000L;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        OrderInfo orderInfo = new OrderInfo(
+                orderId,
+                userId,
+                auctionId,
+                shoeId,
+                OrderStatus.PAYMENT,
+                amount,
+                usedPointAmount,
+                now.plusMinutes(15),
+                now,
+                now
+        );
+
+        given(orderFacade.createOrder(
+                any(UUID.class),
+                any(UUID.class),
+                any(UUID.class),
+                anyLong(),
+                anyLong()
+        )).willReturn(orderInfo);
+
+        // when & then
+        mockMvc.perform(post("/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("신발 경매 주문이 생성되었습니다.")))
+                .andExpect(jsonPath("$.data.orderId").value(orderId.toString()))
+                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.data.auctionId").value(auctionId.toString()))
+                .andExpect(jsonPath("$.data.shoeId").value(shoeId.toString()))
+                .andExpect(jsonPath("$.data.amount").value((int) amount))
+                .andExpect(jsonPath("$.data.usedPointAmount").value((int) usedPointAmount));
+    }
+
+    @Test
+    @DisplayName("주문 생성 실패 - 내부 오류 발생 시 예외 전파")
+    void createOrder_fail_whenInternalErrorOccurs() throws Exception {
+        // given
+        String requestJson = """
+                {
+                  "userId": "11111111-2222-3333-4444-555555555555",
+                  "auctionId": "7c4d3f9a-1b2c-4d5e-9f01-23456789abcd",
+                  "shoeId": "b1a2c3d4-e5f6-7890-abcd-ef0123456789",
+                  "amount": 250000,
+                  "usePointAmount": 10000
+                }
+                """;
+
+        doThrow(new RuntimeException("internal error"))
+                .when(orderFacade)
+                .createOrder(
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        anyLong(),
+                        anyLong()
+                );
+
+        // when & then
+        ServletException ex = assertThrows(ServletException.class, () ->
+                mockMvc.perform(post("/v1/orders")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(requestJson))
+                        .andReturn()
+        );
+    }
+}


### PR DESCRIPTION
## Issue Number
- closed #50 

## Description
- 주문 생성(API) 기능 구현
- Controller → Facade → DomainService → RepositoryImpl 구조로 유즈케이스 구성
- PAYMENT 상태로 주문 생성 및 결제 만료 시간 설정
- BaseEntity(JPA Auditing) 적용 (createdAt, updatedAt 자동 설정)
- Controller/Facade 단위 테스트 추가 (성공/실패 케이스)

## Test Result
<img width="915" height="111" alt="스크린샷 2025-12-05 16 23 08" src="https://github.com/user-attachments/assets/2c606764-b03c-4ee0-848c-ce9a23de440e" />
<img width="915" height="111" alt="스크린샷 2025-12-05 16 23 04" src="https://github.com/user-attachments/assets/5a061a18-5e25-4396-abd7-910b2fe77311" />
<img width="618" height="474" alt="스크린샷 2025-12-05 16 24 12" src="https://github.com/user-attachments/assets/c1ecea6c-4c54-4ed5-8601-e06a646db860" />

## To Reviewer
- 계층 구조 및 책임 분리가 적절한지 확인 부탁드립니다.
- 도메인 서비스 로직 및 예외 흐름 검토 요청드립니다.
