### PR TITLE
Feature/#80 refund create

### DIFF
--- a/backend/order-service/src/main/java/com/bidket/order/application/refund/facade/RefundFacade.java
+++ b/backend/order-service/src/main/java/com/bidket/order/application/refund/facade/RefundFacade.java
@@ -1,0 +1,33 @@
+package com.bidket.order.application.refund.facade;
+
+import com.bidket.order.domain.refund.model.Refund;
+import com.bidket.order.domain.refund.repository.RefundRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefundFacade {
+
+    private final RefundRepository refundRepository;
+
+    public Refund createRefund(
+            UUID paymentId,
+            Long refundAmount,
+            Long refundPointAmount,
+            String reason
+    ) {
+        Refund refund = Refund.request(
+                paymentId,
+                refundAmount,
+                refundPointAmount,
+                reason,
+                LocalDateTime.now()
+        );
+
+        // TODO: Payple 환불 연동 시 실제 PG 환불 요청 및 상태 업데이트 처리 추가
+        return refundRepository.save(refund);
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/domain/refund/model/Refund.java
+++ b/backend/order-service/src/main/java/com/bidket/order/domain/refund/model/Refund.java
@@ -1,0 +1,47 @@
+package com.bidket.order.domain.refund.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record Refund(
+        UUID id,
+        UUID paymentId,
+        Long refundAmount,
+        Long refundedPointAmount,
+        RefundStatus status,
+        String reason,
+        LocalDateTime requestedAt,
+        LocalDateTime approvedAt
+) {
+
+    public Refund {
+        if (refundAmount == null || refundAmount <= 0) {
+            throw new IllegalArgumentException("refundAmount must be positive");
+        }
+        if (refundedPointAmount != null && refundedPointAmount < 0) {
+            throw new IllegalArgumentException("refundedPointAmount must be >= 0");
+        }
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("reason must not be blank");
+        }
+    }
+
+    public static Refund request(
+            UUID paymentId,
+            Long refundAmount,
+            Long refundPointAmount,
+            String reason,
+            LocalDateTime now
+    ) {
+        return new Refund(
+                null,
+                paymentId,
+                refundAmount,
+                refundPointAmount,
+                RefundStatus.REQUESTED,
+                reason,
+                now,
+                null
+        );
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/domain/refund/model/RefundStatus.java
+++ b/backend/order-service/src/main/java/com/bidket/order/domain/refund/model/RefundStatus.java
@@ -1,0 +1,7 @@
+package com.bidket.order.domain.refund.model;
+
+public enum RefundStatus {
+    REQUESTED,  // 환불 요청 접수
+    APPROVED,   // 환불 승인
+    REJECTED    // 환불 거절
+}

--- a/backend/order-service/src/main/java/com/bidket/order/domain/refund/repository/RefundRepository.java
+++ b/backend/order-service/src/main/java/com/bidket/order/domain/refund/repository/RefundRepository.java
@@ -1,0 +1,8 @@
+package com.bidket.order.domain.refund.repository;
+
+import com.bidket.order.domain.refund.model.Refund;
+
+public interface RefundRepository {
+
+    Refund save(Refund refund);
+}

--- a/backend/order-service/src/main/java/com/bidket/order/infrastructure/refund/entity/RefundEntity.java
+++ b/backend/order-service/src/main/java/com/bidket/order/infrastructure/refund/entity/RefundEntity.java
@@ -1,0 +1,67 @@
+package com.bidket.order.infrastructure.refund.entity;
+
+import com.bidket.order.domain.refund.model.Refund;
+import com.bidket.order.domain.refund.model.RefundStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "refunds")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefundEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private UUID paymentId;
+
+    private Long refundAmount;
+
+    private Long refundedPointAmount;
+
+    @Enumerated(EnumType.STRING)
+    private RefundStatus status;
+
+    private String reason;
+
+    private LocalDateTime requestedAt;
+
+    private LocalDateTime approvedAt;
+
+    public static RefundEntity from(Refund refund) {
+        RefundEntity entity = new RefundEntity();
+        entity.paymentId = refund.paymentId();
+        entity.refundAmount = refund.refundAmount();
+        entity.refundedPointAmount = refund.refundedPointAmount();
+        entity.status = refund.status();
+        entity.reason = refund.reason();
+        entity.requestedAt = refund.requestedAt();
+        entity.approvedAt = refund.approvedAt();
+        return entity;
+    }
+
+    public Refund toModel() {
+        return new Refund(
+                id,
+                paymentId,
+                refundAmount,
+                refundedPointAmount,
+                status,
+                reason,
+                requestedAt,
+                approvedAt
+        );
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/infrastructure/refund/impl/RefundRepositoryImpl.java
+++ b/backend/order-service/src/main/java/com/bidket/order/infrastructure/refund/impl/RefundRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.bidket.order.infrastructure.refund.impl;
+
+import com.bidket.order.domain.refund.model.Refund;
+import com.bidket.order.domain.refund.repository.RefundRepository;
+import com.bidket.order.infrastructure.refund.entity.RefundEntity;
+import com.bidket.order.infrastructure.refund.repository.RefundJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefundRepositoryImpl implements RefundRepository {
+
+    private final RefundJpaRepository jpaRepository;
+
+    @Override
+    public Refund save(Refund refund) {
+        RefundEntity saved = jpaRepository.save(RefundEntity.from(refund));
+        return saved.toModel();
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/infrastructure/refund/repository/RefundJpaRepository.java
+++ b/backend/order-service/src/main/java/com/bidket/order/infrastructure/refund/repository/RefundJpaRepository.java
@@ -1,0 +1,9 @@
+package com.bidket.order.infrastructure.refund.repository;
+
+import com.bidket.order.infrastructure.refund.entity.RefundEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefundJpaRepository extends JpaRepository<RefundEntity, UUID> {
+
+}

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/order/api/OrderController.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/order/api/OrderController.java
@@ -60,12 +60,10 @@ public class OrderController {
             @Valid @RequestBody OrderCreateRequest request
     ) {
         // TODO: 인증 적용 예정
-        UUID userId = UUID.fromString(request.userId());
-
         OrderInfo orderInfo = orderFacade.createOrder(
-                userId,
-                UUID.fromString(request.auctionId()),
-                UUID.fromString(request.shoeId()),
+                request.userId(),
+                request.auctionId(),
+                request.shoeId(),
                 request.amount(),
                 request.usePointAmount()
         );
@@ -79,13 +77,11 @@ public class OrderController {
     public ApiResponse<PageResponse<OrderSummaryResponse>> getOrders(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam String userId // TODO: 인증 적용 예정 (토큰에서 userId 추출)
+            @RequestParam UUID userId // TODO: 인증 적용 예정 (토큰에서 userId 추출)
     ) {
-        // TODO: 인증 적용 예정
-        UUID userUuid = UUID.fromString(userId);
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<OrderSummaryInfo> orderPage = orderFacade.getOrders(userUuid, pageable);
+        Page<OrderSummaryInfo> orderPage = orderFacade.getOrders(userId, pageable);
 
         List<OrderSummaryResponse> content = orderPage.getContent()
                 .stream()

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/order/dto/request/OrderCreateRequest.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/order/dto/request/OrderCreateRequest.java
@@ -2,24 +2,23 @@ package com.bidket.order.presentation.order.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
 
 @Schema(description = "신발 경매 주문 생성 요청")
 public record OrderCreateRequest(
 
         @NotNull
         @Schema(description = "주문 요청 유저 ID", example = "11111111-2222-3333-4444-555555555555")
-        String userId,
+        UUID userId,
 
-        @NotBlank
+        @NotNull
         @Schema(description = "경매 ID", example = "7c4d3f9a-1b2c-4d5e-9f01-23456789abcd")
-        String auctionId,
+        UUID auctionId,
 
-        @NotBlank
+        @NotNull
         @Schema(description = "신발 ID", example = "b1a2c3d4-e5f6-7890-abcd-ef0123456789")
-        String shoeId,
-
+        UUID shoeId,
 
         @Min(1)
         @NotNull

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/refund/api/RefundController.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/refund/api/RefundController.java
@@ -1,0 +1,50 @@
+// com/bidket/order/presentation/refund/api/RefundController.java
+package com.bidket.order.presentation.refund.api;
+
+import com.bidket.common.presentation.response.ApiResponse;
+import com.bidket.order.application.refund.facade.RefundFacade;
+import com.bidket.order.domain.refund.model.Refund;
+import com.bidket.order.presentation.refund.dto.request.RefundCreateRequest;
+import com.bidket.order.presentation.refund.dto.response.RefundCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Refund", description = "환불 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/refunds")
+public class RefundController {
+
+    private final RefundFacade refundFacade;
+
+    @Operation(
+            summary = "환불 요청",
+            description = "결제 ID와 환불 정보를 기반으로 환불 요청을 생성합니다.\n\n"
+                    + "※ Payple(PG) 환불 연동 전 단계로, 현재는 내부 환불 요청 데이터만 생성합니다."
+    )
+    @PostMapping("/{paymentId}")
+    public ApiResponse<RefundCreateResponse> createRefund(
+            @PathVariable UUID paymentId,
+            @RequestBody RefundCreateRequest request
+    ) {
+        // TODO: 인증 적용 예정
+        Refund refund = refundFacade.createRefund(
+                paymentId,
+                request.refundAmount(),
+                request.refundPointAmount(),
+                request.reason()
+        );
+
+        return ApiResponse.success(
+                "환불 요청이 접수되었습니다.",
+                RefundCreateResponse.from(refund)
+        );
+    }
+}

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/refund/dto/request/RefundCreateRequest.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/refund/dto/request/RefundCreateRequest.java
@@ -1,0 +1,18 @@
+package com.bidket.order.presentation.refund.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "환불 요청 생성 요청")
+public record RefundCreateRequest(
+
+        @Schema(description = "환불 금액(원)", example = "50000")
+        Long refundAmount,
+
+        @Schema(description = "환불 포인트 금액(원)", example = "10000")
+        Long refundPointAmount,
+
+        @Schema(description = "환불 사유", example = "단순 변심")
+        String reason
+) {
+
+}

--- a/backend/order-service/src/main/java/com/bidket/order/presentation/refund/dto/response/RefundCreateResponse.java
+++ b/backend/order-service/src/main/java/com/bidket/order/presentation/refund/dto/response/RefundCreateResponse.java
@@ -1,0 +1,41 @@
+package com.bidket.order.presentation.refund.dto.response;
+
+import com.bidket.order.domain.refund.model.Refund;
+import com.bidket.order.domain.refund.model.RefundStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "환불 요청 생성 응답")
+public record RefundCreateResponse(
+
+        @Schema(description = "환불 ID", example = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        UUID refundId,
+
+        @Schema(description = "결제 ID", example = "a1b2c3d4-5678-90ab-cdef-1234567890ab")
+        UUID paymentId,
+
+        @Schema(description = "환불 금액(원)", example = "50000")
+        Long refundAmount,
+
+        @Schema(description = "환불된 포인트 금액(원)", example = "10000")
+        Long refundedPointAmount,
+
+        @Schema(description = "환불 상태", example = "REQUESTED")
+        RefundStatus status,
+
+        @Schema(description = "환불 요청 일시", example = "2025-11-26T11:00:00")
+        LocalDateTime requestedAt
+) {
+
+    public static RefundCreateResponse from(Refund refund) {
+        return new RefundCreateResponse(
+                refund.id(),
+                refund.paymentId(),
+                refund.refundAmount(),
+                refund.refundedPointAmount(),
+                refund.status(),
+                refund.requestedAt()
+        );
+    }
+}

--- a/backend/order-service/src/test/java/com/bidket/order/application/refund/facade/RefundFacade.java
+++ b/backend/order-service/src/test/java/com/bidket/order/application/refund/facade/RefundFacade.java
@@ -1,0 +1,75 @@
+package com.bidket.order.application.refund.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.bidket.order.domain.refund.model.Refund;
+import com.bidket.order.domain.refund.repository.RefundRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RefundFacadeTest {
+
+    @Mock
+    private RefundRepository refundRepository;
+
+    @InjectMocks
+    private RefundFacade refundFacade;
+
+    @Test
+    @DisplayName("환불 생성 성공 - Refund를 반환한다")
+    void createRefund_success() {
+        // given
+        UUID paymentId = UUID.fromString("a1b2c3d4-5678-90ab-cdef-1234567890ab");
+        long refundAmount = 50_000L;
+        long refundPointAmount = 10_000L;
+        String reason = "단순 변심";
+
+        Refund savedRefund = Mockito.mock(Refund.class);
+
+        Mockito.when(refundRepository.save(any(Refund.class)))
+                .thenReturn(savedRefund);
+
+        // when
+        Refund result = refundFacade.createRefund(
+                paymentId,
+                refundAmount,
+                refundPointAmount,
+                reason
+        );
+
+        // then
+        assertThat(result).isEqualTo(savedRefund);
+    }
+
+    @Test
+    @DisplayName("환불 생성 실패 - Repository에서 예외 발생 시 예외를 전파한다")
+    void createRefund_fail_whenRepositoryThrows() {
+        // given
+        UUID paymentId = UUID.fromString("a1b2c3d4-5678-90ab-cdef-1234567890ab");
+        long refundAmount = 50_000L;
+        long refundPointAmount = 10_000L;
+        String reason = "단순 변심";
+
+        Mockito.when(refundRepository.save(any(Refund.class)))
+                .thenThrow(new RuntimeException("DB error"));
+
+        // when & then
+        assertThrows(RuntimeException.class, () ->
+                refundFacade.createRefund(
+                        paymentId,
+                        refundAmount,
+                        refundPointAmount,
+                        reason
+                )
+        );
+    }
+}

--- a/backend/order-service/src/test/java/com/bidket/order/presentation/refund/api/RefundController.java
+++ b/backend/order-service/src/test/java/com/bidket/order/presentation/refund/api/RefundController.java
@@ -1,0 +1,114 @@
+// src/test/java/com/bidket/order/presentation/refund/api/RefundControllerTest.java
+package com.bidket.order.presentation.refund.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bidket.order.application.refund.facade.RefundFacade;
+import com.bidket.order.domain.refund.model.Refund;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(RefundController.class)
+class RefundControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private RefundFacade refundFacade;
+
+    @Test
+    @DisplayName("환불 요청 생성 성공 - 200 OK와 ApiResponse 반환")
+    void createRefund_success() throws Exception {
+        // given
+        UUID paymentId = UUID.fromString("a1b2c3d4-5678-90ab-cdef-1234567890ab");
+
+        String requestJson = """
+                {
+                  "refundAmount": 50000,
+                  "refundPointAmount": 10000,
+                  "reason": "단순 변심"
+                }
+                """;
+
+        UUID refundId = UUID.fromString("d9a28926-8f22-49bb-8044-a51b83074e50");
+
+        Refund refund = Mockito.mock(Refund.class);
+        Mockito.when(refund.id()).thenReturn(refundId);
+        Mockito.when(refund.paymentId()).thenReturn(paymentId);
+        Mockito.when(refund.refundAmount()).thenReturn(50_000L);
+
+        given(refundFacade.createRefund(
+                any(UUID.class),
+                anyLong(),
+                anyLong(),
+                anyString()
+        )).willReturn(refund);
+
+        // when & then
+        mockMvc.perform(post("/v1/refunds/{paymentId}", paymentId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("환불 요청이 접수되었습니다.")))
+                .andExpect(jsonPath("$.data.refundId").value(refundId.toString()))
+                .andExpect(jsonPath("$.data.paymentId").value(paymentId.toString()))
+                .andExpect(jsonPath("$.data.refundAmount").value(50_000));
+    }
+
+    @Test
+    @DisplayName("환불 요청 생성 실패 - 내부 오류 발생 시 예외 전파")
+    void createRefund_fail_whenInternalErrorOccurs() throws Exception {
+        // given
+        UUID paymentId = UUID.fromString("a1b2c3d4-5678-90ab-cdef-1234567890ab");
+
+        String requestJson = """
+                {
+                  "refundAmount": 50000,
+                  "refundPointAmount": 10000,
+                  "reason": "단순 변심"
+                }
+                """;
+
+        doThrow(new RuntimeException("internal error"))
+                .when(refundFacade)
+                .createRefund(
+                        any(UUID.class),
+                        anyLong(),
+                        anyLong(),
+                        anyString()
+                );
+
+        // when & then
+        assertThrows(ServletException.class, () ->
+                mockMvc.perform(post("/v1/refunds/{paymentId}", paymentId.toString())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(requestJson))
+                        .andReturn()
+        );
+    }
+}


### PR DESCRIPTION
## Issue Number
- closed #80 

## Description
- 환불 요청 생성 기능에 대한 단위 테스트 추가
- 정상 흐름(REQUESTED 상태 저장)과 예외 전파 흐름 검증
- Refund.request 팩토리 메서드를 활용하도록 테스트 로직을 실제 도메인 동작과 일치

## Test Result
<img width="824" height="110" alt="스크린샷 2025-12-09 22 44 43" src="https://github.com/user-attachments/assets/bf205a25-2a7f-400c-875a-81481a3e80b2" />
<img width="824" height="110" alt="스크린샷 2025-12-09 22 35 39" src="https://github.com/user-attachments/assets/92846946-7d0d-4457-8c45-41523a740a4f" />
<img width="632" height="414" alt="스크린샷 2025-12-09 21 12 37" src="https://github.com/user-attachments/assets/5d4385da-7626-485a-bbeb-f71216cc3bdf" />

## To Reviewer
- Test에서 사용한 Refund 팩토리 메서드와 저장 로직이 실제 도메인 의도와 잘 맞는지 확인 부탁드립니다.