### PR TITLE
Feature/#128 프로필 수정 API 추가 (닉네임/전화번호/이메일)

### DIFF
--- a/backend/user-service/src/main/java/com/bidket/user/application/service/ProfileUpdateService.java
+++ b/backend/user-service/src/main/java/com/bidket/user/application/service/ProfileUpdateService.java
@@ -1,0 +1,152 @@
+package com.bidket.user.application.service;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.bidket.user.global.security.AuthenticationHelper;
+import com.bidket.user.infrastructure.persistence.entity.User;
+import com.bidket.user.infrastructure.persistence.repository.UserRepository;
+import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
+import com.bidket.user.presentation.dto.response.ProfileUpdateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * 프로필 수정 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ProfileUpdateService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * RFC 5322 기반 이메일 형식 검증 패턴
+     */
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$"
+    );
+
+    /**
+     * 프로필 수정
+     * 
+     * @param request 프로필 수정 요청 정보
+     * @return 프로필 수정 응답
+     * @throws UserException 최소 1개 필드 미포함, 이메일/닉네임 중복, 이메일 형식 오류 시
+     */
+    @Transactional
+    public ProfileUpdateResponse updateProfile(ProfileUpdateRequest request) {
+        // Bean Validation에서 최소 1개 필드 검증이 이미 수행됨 (@AtLeastOneField)
+        
+        // 현재 로그인한 사용자 ID 추출
+        UUID userId = AuthenticationHelper.getCurrentUserId();
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 닉네임 검증 및 업데이트
+        String updatedNickname = null; // null이면 업데이트하지 않음
+        if (request.nickname() != null && !request.nickname().isBlank()) {
+            // 닉네임 형식 검증
+            if (!isValidNicknameFormat(request.nickname())) {
+                throw new UserException(UserErrorCode.VALIDATION_FAILED);
+            }
+
+            // 닉네임 중복 확인 (자기 자신 제외)
+            if (userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+                throw new UserException(UserErrorCode.NICKNAME_DUPLICATE);
+            }
+
+            updatedNickname = request.nickname();
+        }
+
+        // 전화번호 검증 및 업데이트 (하이픈 및 공백 제거)
+        String updatedPhone = null; // null이면 업데이트하지 않음
+        if (request.phone() != null && !request.phone().isBlank()) {
+            // 하이픈과 공백 제거 (정규식에서 하이픈과 공백을 허용하지만, 저장 시에는 숫자만 저장)
+            String normalizedPhone = request.phone()
+                    .replaceAll("-", "")
+                    .replaceAll("\\s", ""); // 모든 공백 문자 제거 (스페이스, 탭 등)
+            // 빈 문자열이면 null로 정규화 (정규식에서 최소 1글자 검증하지만 방어적 처리)
+            if (!normalizedPhone.isBlank()) {
+                updatedPhone = normalizedPhone;
+            }
+        }
+
+        // 이메일 검증 및 업데이트
+        String updatedEmail = null; // null이면 업데이트하지 않음
+        if (request.email() != null && !request.email().isBlank()) {
+            // 이메일 형식 검증
+            if (!isValidEmailFormat(request.email())) {
+                throw new UserException(UserErrorCode.INVALID_EMAIL_FORMAT);
+            }
+
+            // 이메일 중복 확인 (자기 자신 제외)
+            if (userRepository.existsByEmailAndIdNot(request.email(), userId)) {
+                throw new UserException(UserErrorCode.EMAIL_DUPLICATE);
+            }
+
+            updatedEmail = request.email();
+        }
+
+        // 프로필 업데이트
+        user.updateProfileFields(updatedNickname, updatedPhone, updatedEmail);
+
+        // @Transactional + JPA 더티 체킹으로 자동 업데이트됨 (save() 불필요)
+        // JPA Auditing으로 updatedAt 자동 설정됨
+
+        // 응답 생성
+        return ProfileUpdateResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .phone(user.getPhone())
+                .email(user.getEmail())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 이메일 형식 검증
+     * 
+     * @param email 검증할 이메일 주소
+     * @return 유효한 형식이면 true, 아니면 false
+     */
+    private boolean isValidEmailFormat(String email) {
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        
+        // 기본 길이 체크 (너무 긴 이메일 방지)
+        if (email.length() > 255) {
+            return false;
+        }
+        
+        return EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    /**
+     * 닉네임 형식 검증
+     * 
+     * @param nickname 검증할 닉네임
+     * @return 유효한 형식이면 true, 아니면 false
+     */
+    private boolean isValidNicknameFormat(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            return false;
+        }
+        
+        // 기본 길이 체크 (2자 이상 100자 이하)
+        if (nickname.length() < 2 || nickname.length() > 100) {
+            return false;
+        }
+        
+        // 한글, 영문, 숫자, 언더스코어, 하이픈 허용
+        Pattern nicknamePattern = Pattern.compile("^[가-힣a-zA-Z0-9_-]+$");
+        return nicknamePattern.matcher(nickname).matches();
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
@@ -85,6 +85,22 @@ public class User extends BaseEntity {
         this.phone = phone;
     }
 
+    /**
+     * 프로필 수정 (nickname, phone, email)
+     * 각 필드는 null이 아닌 경우에만 업데이트
+     */
+    public void updateProfileFields(String nickname, String phone, String email) {
+        if (nickname != null && !nickname.isBlank()) {
+            this.nickname = nickname;
+        }
+        if (phone != null && !phone.isBlank()) {
+            this.phone = phone;
+        }
+        if (email != null && !email.isBlank()) {
+            this.email = email;
+        }
+    }
+
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
     }

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/repository/UserRepository.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/repository/UserRepository.java
@@ -26,5 +26,11 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     
     /** 닉네임 중복 확인 */
     boolean existsByNickname(String nickname);
+
+    /** 특정 회원을 제외하고 이메일 중복 확인 */
+    boolean existsByEmailAndIdNot(String email, UUID id);
+
+    /** 특정 회원을 제외하고 닉네임 중복 확인 */
+    boolean existsByNicknameAndIdNot(String nickname, UUID id);
 }
 

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
@@ -13,9 +13,11 @@ import com.bidket.user.application.service.MyInfoService;
 import com.bidket.user.application.service.PermissionsService;
 import com.bidket.user.application.service.PointBalanceService;
 import com.bidket.user.application.service.PointHistoryService;
+import com.bidket.user.application.service.ProfileUpdateService;
 import com.bidket.user.application.service.SignupService;
 import com.bidket.user.presentation.dto.request.BlacklistRegisterRequest;
 import com.bidket.user.presentation.dto.request.LoginRequest;
+import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
 import com.bidket.user.presentation.dto.request.SignupRequest;
 import com.bidket.user.presentation.dto.response.BidEligibilityResponse;
 import com.bidket.user.presentation.dto.response.BlacklistListResponse;
@@ -29,6 +31,7 @@ import com.bidket.user.presentation.dto.response.MyInfoResponse;
 import com.bidket.user.presentation.dto.response.PermissionsResponse;
 import com.bidket.user.presentation.dto.response.PointBalanceResponse;
 import com.bidket.user.presentation.dto.response.PointHistoryResponse;
+import com.bidket.user.presentation.dto.response.ProfileUpdateResponse;
 import com.bidket.user.presentation.dto.response.SignupResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -43,6 +46,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -74,6 +78,7 @@ public class MemberController {
     private final BidEligibilityService bidEligibilityService;
     private final PointBalanceService pointBalanceService;
     private final PointHistoryService pointHistoryService;
+    private final ProfileUpdateService profileUpdateService;
 
     /**
      * 이메일 중복 체크 API
@@ -217,6 +222,45 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success("내 정보 조회에 성공했습니다.", response));
+    }
+
+    /**
+     * 프로필 수정 API
+     * @param request 프로필 수정 요청 정보 (nickname, phone, email 중 최소 1개 필수)
+     * @return 프로필 수정 응답 (userId, nickname, phone, email, updatedAt)
+     */
+    @Operation(
+            summary = "프로필 수정",
+            description = "현재 로그인한 사용자의 프로필 정보를 수정합니다. 최소 1개 필드는 포함되어야 합니다.",
+            tags = {"02. 회원 정보"},
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = ProfileUpdateResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (최소 1개 필드 미포함, 형식 오류 등)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "중복된 이메일 또는 닉네임"
+            )
+    })
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<ProfileUpdateResponse>> updateProfile(
+            @RequestBody @Valid ProfileUpdateRequest request) {
+        ProfileUpdateResponse response = profileUpdateService.updateProfile(request);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success("프로필 수정에 성공했습니다.", response));
     }
 
     /**

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/ProfileUpdateRequest.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,42 @@
+package com.bidket.user.presentation.dto.request;
+
+import com.bidket.user.presentation.dto.request.validation.AtLeastOneField;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로필 수정 요청 DTO
+ * 최소 1개 필드는 포함되어야 함 (nickname / phone / email 중 택1 이상)
+ */
+@AtLeastOneField
+@Schema(description = "프로필 수정 요청")
+public record ProfileUpdateRequest(
+        /** 변경할 닉네임 */
+        @Size(max = 100, message = "닉네임은 100자 이하여야 합니다.")
+        @Schema(description = "변경할 닉네임", example = "콘서트대장")
+        String nickname,
+
+        /** 변경할 전화번호 (하이픈, 공백 포함 가능, 서버에서 하이픈과 공백 제거 후 저장) */
+        @Pattern(regexp = "^[0-9]+([-\\s][0-9]+)*$", message = "전화번호는 숫자로 시작해야 하며, 하이픈, 공백, 숫자 조합만 허용됩니다.")
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다.")
+        @Schema(description = "변경할 전화번호 (하이픈, 공백 포함 가능, 서버에서 하이픈과 공백 제거 후 저장)", example = "01012345678")
+        String phone,
+
+        /** 변경할 이메일 */
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Size(max = 255, message = "이메일은 255자 이하여야 합니다.")
+        @Schema(description = "변경할 이메일", example = "newmail@example.com")
+        String email
+) {
+    /**
+     * 최소 1개 필드가 포함되어야 함
+     */
+    public boolean hasAtLeastOneField() {
+        return (nickname != null && !nickname.isBlank()) ||
+               (phone != null && !phone.isBlank()) ||
+               (email != null && !email.isBlank());
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneField.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneField.java
@@ -1,0 +1,24 @@
+package com.bidket.user.presentation.dto.request.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 최소 1개 필드가 포함되어야 함을 검증하는 어노테이션
+ */
+@Documented
+@Constraint(validatedBy = AtLeastOneFieldValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AtLeastOneField {
+    String message() default "최소 1개 필드는 포함되어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneFieldValidator.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneFieldValidator.java
@@ -1,0 +1,36 @@
+package com.bidket.user.presentation.dto.request.validation;
+
+import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/*
+ * 최소 1개 필드 포함 검증 Validator
+ */
+public class AtLeastOneFieldValidator implements ConstraintValidator<AtLeastOneField, ProfileUpdateRequest> {
+
+    @Override
+    public void initialize(AtLeastOneField constraintAnnotation) {
+        // 초기화 로직이 필요한 경우 여기에 작성
+    }
+
+    @Override
+    public boolean isValid(ProfileUpdateRequest request, ConstraintValidatorContext context) {
+        if (request == null) {
+            return false;
+        }
+
+        // ProfileUpdateRequest의 hasAtLeastOneField() 메서드를 직접 호출
+        boolean isValid = request.hasAtLeastOneField();
+
+        if (!isValid) {
+            // 커스텀 에러 메시지 설정
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("최소 1개 필드는 포함되어야 합니다. (nickname, phone, email 중 택1 이상)")
+                    .addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/ProfileUpdateResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/ProfileUpdateResponse.java
@@ -1,0 +1,36 @@
+package com.bidket.user.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 프로필 수정 응답 DTO
+ */
+@Builder
+@Schema(description = "프로필 수정 응답")
+public record ProfileUpdateResponse(
+        /** 회원 ID (UUID) */
+        @Schema(description = "회원 ID", example = "c12f92cd-7a6e-4c92-ae01-e77ca1cafe56")
+        UUID userId,
+
+        /** 변경 후 닉네임 */
+        @Schema(description = "변경 후 닉네임", example = "콘서트대장")
+        String nickname,
+
+        /** 변경 후 전화번호 (미변경/미보유면 null 가능) */
+        @Schema(description = "변경 후 전화번호", example = "01012345678", nullable = true)
+        String phone,
+
+        /** 변경 후 이메일 (미변경/미보유면 null 가능) */
+        @Schema(description = "변경 후 이메일", example = "newmail@example.com", nullable = true)
+        String email,
+
+        /** 수정 시각 */
+        @Schema(description = "수정 시각", example = "2025-11-27T12:10:00", type = "string", format = "date-time")
+        LocalDateTime updatedAt
+) {
+}
+


### PR DESCRIPTION
## Issue Number
- closed #[128]

## Description
- 프로필 수정 API에서 닉네임/전화번호/이메일 항목 변경 지원

## Test Result
닉네임 변경
<img width="795" height="425" alt="image" src="https://github.com/user-attachments/assets/6d74d2a5-6d3a-4920-9207-b1e58ce2dfd7" />

전화번호변경
<img width="750" height="388" alt="image" src="https://github.com/user-attachments/assets/318a5ffa-ed03-4dfe-89d4-036eff879a90" />

이메일변경
<img width="792" height="430" alt="image" src="https://github.com/user-attachments/assets/e6c6c403-b16a-40a9-8a0e-8a933cfa9835" />

닉네임, 전화번호, 이메일변경
<img width="784" height="444" alt="image" src="https://github.com/user-attachments/assets/ac169a4c-40d9-410f-b6fd-849b35a06e42" />


## To Reviewer

