### PR TITLE
Feature/#134 회원 로그아웃 API 구현

### DIFF
--- a/backend/user-service/src/main/java/com/bidket/user/application/service/LogoutService.java
+++ b/backend/user-service/src/main/java/com/bidket/user/application/service/LogoutService.java
@@ -1,0 +1,43 @@
+package com.bidket.user.application.service;
+
+import com.bidket.user.global.security.AuthenticationHelper;
+import com.bidket.user.infrastructure.persistence.repository.RefreshTokenRepository;
+import com.bidket.user.presentation.dto.response.LogoutResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 로그아웃 서비스
+ * 1. Authorization 헤더에서 사용자 ID 추출 (SecurityContext)
+ * 2. 해당 userId에 연결된 모든 Refresh Token 삭제
+ * 3. 멱등성 보장: 이미 삭제된 상태여도 성공 응답 반환
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 로그아웃 처리
+     * Authorization 헤더만으로 사용자 식별하여 해당 사용자의 모든 Refresh Token을 삭제합니다.
+     * @return 로그아웃 응답 (success)
+     */
+    @Transactional
+    public LogoutResponse logout() {
+        // 1. Authorization 헤더에서 사용자 ID 추출 (SecurityContext)
+        UUID userId = AuthenticationHelper.getCurrentUserId();
+
+        // 2. 해당 userId에 연결된 모든 Refresh Token 삭제
+        refreshTokenRepository.deleteByUserId(userId);
+
+        // 멱등성 보장: 이미 삭제된 상태여도 성공 응답 반환
+        return new LogoutResponse(true);
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/application/service/MemberDeactivationService.java
+++ b/backend/user-service/src/main/java/com/bidket/user/application/service/MemberDeactivationService.java
@@ -1,0 +1,60 @@
+package com.bidket.user.application.service;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.bidket.user.global.security.AuthenticationHelper;
+import com.bidket.user.infrastructure.persistence.entity.User;
+import com.bidket.user.infrastructure.persistence.repository.UserRepository;
+import com.bidket.user.presentation.dto.request.MemberDeactivationRequest;
+import com.bidket.user.presentation.dto.response.MemberDeactivationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 회원 탈퇴(비활성화) 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class MemberDeactivationService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 회원 탈퇴(비활성화) 처리
+     * 논리삭제 방식으로 상태를 WITHDRAWN으로 변경
+     * @param request 회원 탈퇴 요청 정보 (reason - 선택사항)
+     * @return 회원 탈퇴 응답 (memberId, status, deactivatedAt)
+     * @throws UserException 사용자를 찾을 수 없는 경우
+     */
+    @Transactional
+    public MemberDeactivationResponse deactivateMember(MemberDeactivationRequest request) {
+        // 현재 로그인한 사용자 ID 추출
+        UUID userId = AuthenticationHelper.getCurrentUserId();
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 이미 탈퇴한 사용자인지 확인
+        if (user.getStatus() == com.bidket.user.domain.model.UserStatus.WITHDRAWN) {
+            throw new UserException(UserErrorCode.ALREADY_WITHDRAWN);
+        }
+
+        // 비활성화 처리 (상태를 WITHDRAWN으로 변경 및 deactivatedAt 설정)
+        user.withdraw();
+
+        // @Transactional + JPA 더티 체킹으로 자동 업데이트됨 (save() 불필요)
+        // JPA Auditing으로 updatedAt 자동 설정됨
+
+        // 응답 생성 (user에 저장된 값을 그대로 사용)
+        return MemberDeactivationResponse.builder()
+                .memberId(user.getId())
+                .status(user.getStatus())
+                .deactivatedAt(user.getDeactivatedAt())
+                .build();
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/application/service/PasswordChangeService.java
+++ b/backend/user-service/src/main/java/com/bidket/user/application/service/PasswordChangeService.java
@@ -1,0 +1,81 @@
+package com.bidket.user.application.service;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.bidket.user.domain.model.Provider;
+import com.bidket.user.global.security.AuthenticationHelper;
+import com.bidket.user.global.security.PasswordEncoder;
+import com.bidket.user.global.security.PasswordValidator;
+import com.bidket.user.infrastructure.persistence.entity.User;
+import com.bidket.user.infrastructure.persistence.repository.UserRepository;
+import com.bidket.user.presentation.dto.request.PasswordChangeRequest;
+import com.bidket.user.presentation.dto.response.PasswordChangeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 비밀번호 변경 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class PasswordChangeService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final PasswordValidator passwordValidator;
+
+    /**
+     * 비밀번호 변경
+     * @param request 비밀번호 변경 요청 정보 (currentPassword, newPassword)
+     * @return 비밀번호 변경 응답 (success, changedAt)
+     * @throws UserException 현재 비밀번호 불일치, 새 비밀번호 강도 부족, 사용자 없음, 새 비밀번호가 현재 비밀번호와 동일한 경우
+     */
+    @Transactional
+    public PasswordChangeResponse changePassword(PasswordChangeRequest request) {
+        // 현재 로그인한 사용자 ID 추출
+        UUID userId = AuthenticationHelper.getCurrentUserId();
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // LOCAL provider 확인 (소셜 로그인 사용자는 비밀번호 변경 불가)
+        if (user.getProvider() != Provider.LOCAL) {
+            throw new UserException(UserErrorCode.PASSWORD_CHANGE_NOT_ALLOWED);
+        }
+
+        // 현재 비밀번호 검증
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        // 새 비밀번호가 현재 비밀번호와 동일한지 확인
+        if (passwordEncoder.matches(request.newPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.VALIDATION_FAILED);
+        }
+
+        // 새 비밀번호 강도 검증
+        if (!passwordValidator.isValid(request.newPassword())) {
+            throw new UserException(UserErrorCode.WEAK_PASSWORD);
+        }
+
+        // 새 비밀번호 암호화
+        String encodedNewPassword = passwordEncoder.encode(request.newPassword());
+
+        // 비밀번호 업데이트
+        user.updatePassword(encodedNewPassword);
+
+        // @Transactional + JPA 더티 체킹으로 자동 업데이트됨 (save() 불필요)
+        // JPA Auditing으로 updatedAt 자동 설정됨
+
+        // 응답 생성 (DB에 저장된 변경 시각 사용)
+        return PasswordChangeResponse.builder()
+                .success(true)
+                .changedAt(user.getUpdatedAt())
+                .build();
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/application/service/ProfileUpdateService.java
+++ b/backend/user-service/src/main/java/com/bidket/user/application/service/ProfileUpdateService.java
@@ -1,0 +1,152 @@
+package com.bidket.user.application.service;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.bidket.user.global.security.AuthenticationHelper;
+import com.bidket.user.infrastructure.persistence.entity.User;
+import com.bidket.user.infrastructure.persistence.repository.UserRepository;
+import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
+import com.bidket.user.presentation.dto.response.ProfileUpdateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * 프로필 수정 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ProfileUpdateService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * RFC 5322 기반 이메일 형식 검증 패턴
+     */
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$"
+    );
+
+    /**
+     * 프로필 수정
+     * 
+     * @param request 프로필 수정 요청 정보
+     * @return 프로필 수정 응답
+     * @throws UserException 최소 1개 필드 미포함, 이메일/닉네임 중복, 이메일 형식 오류 시
+     */
+    @Transactional
+    public ProfileUpdateResponse updateProfile(ProfileUpdateRequest request) {
+        // Bean Validation에서 최소 1개 필드 검증이 이미 수행됨 (@AtLeastOneField)
+        
+        // 현재 로그인한 사용자 ID 추출
+        UUID userId = AuthenticationHelper.getCurrentUserId();
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 닉네임 검증 및 업데이트
+        String updatedNickname = null; // null이면 업데이트하지 않음
+        if (request.nickname() != null && !request.nickname().isBlank()) {
+            // 닉네임 형식 검증
+            if (!isValidNicknameFormat(request.nickname())) {
+                throw new UserException(UserErrorCode.VALIDATION_FAILED);
+            }
+
+            // 닉네임 중복 확인 (자기 자신 제외)
+            if (userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+                throw new UserException(UserErrorCode.NICKNAME_DUPLICATE);
+            }
+
+            updatedNickname = request.nickname();
+        }
+
+        // 전화번호 검증 및 업데이트 (하이픈 및 공백 제거)
+        String updatedPhone = null; // null이면 업데이트하지 않음
+        if (request.phone() != null && !request.phone().isBlank()) {
+            // 하이픈과 공백 제거 (정규식에서 하이픈과 공백을 허용하지만, 저장 시에는 숫자만 저장)
+            String normalizedPhone = request.phone()
+                    .replaceAll("-", "")
+                    .replaceAll("\\s", ""); // 모든 공백 문자 제거 (스페이스, 탭 등)
+            // 빈 문자열이면 null로 정규화 (정규식에서 최소 1글자 검증하지만 방어적 처리)
+            if (!normalizedPhone.isBlank()) {
+                updatedPhone = normalizedPhone;
+            }
+        }
+
+        // 이메일 검증 및 업데이트
+        String updatedEmail = null; // null이면 업데이트하지 않음
+        if (request.email() != null && !request.email().isBlank()) {
+            // 이메일 형식 검증
+            if (!isValidEmailFormat(request.email())) {
+                throw new UserException(UserErrorCode.INVALID_EMAIL_FORMAT);
+            }
+
+            // 이메일 중복 확인 (자기 자신 제외)
+            if (userRepository.existsByEmailAndIdNot(request.email(), userId)) {
+                throw new UserException(UserErrorCode.EMAIL_DUPLICATE);
+            }
+
+            updatedEmail = request.email();
+        }
+
+        // 프로필 업데이트
+        user.updateProfileFields(updatedNickname, updatedPhone, updatedEmail);
+
+        // @Transactional + JPA 더티 체킹으로 자동 업데이트됨 (save() 불필요)
+        // JPA Auditing으로 updatedAt 자동 설정됨
+
+        // 응답 생성
+        return ProfileUpdateResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .phone(user.getPhone())
+                .email(user.getEmail())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 이메일 형식 검증
+     * 
+     * @param email 검증할 이메일 주소
+     * @return 유효한 형식이면 true, 아니면 false
+     */
+    private boolean isValidEmailFormat(String email) {
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        
+        // 기본 길이 체크 (너무 긴 이메일 방지)
+        if (email.length() > 255) {
+            return false;
+        }
+        
+        return EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    /**
+     * 닉네임 형식 검증
+     * 
+     * @param nickname 검증할 닉네임
+     * @return 유효한 형식이면 true, 아니면 false
+     */
+    private boolean isValidNicknameFormat(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            return false;
+        }
+        
+        // 기본 길이 체크 (2자 이상 100자 이하)
+        if (nickname.length() < 2 || nickname.length() > 100) {
+            return false;
+        }
+        
+        // 한글, 영문, 숫자, 언더스코어, 하이픈 허용
+        Pattern nicknamePattern = Pattern.compile("^[가-힣a-zA-Z0-9_-]+$");
+        return nicknamePattern.matcher(nickname).matches();
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/domain/exception/UserErrorCode.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/exception/UserErrorCode.java
@@ -16,6 +16,8 @@ public enum UserErrorCode {
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "입력값 검증에 실패했습니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "잘못된 이메일 형식입니다."),
     WEAK_PASSWORD(HttpStatus.BAD_REQUEST, "WEAK_PASSWORD", "비밀번호 강도가 부족합니다."),
+    PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PASSWORD_CHANGE_NOT_ALLOWED", "소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다."),
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_CURRENT_PASSWORD", "현재 비밀번호가 올바르지 않습니다."),
     
     // 401 Unauthorized
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/backend/user-service/src/main/java/com/bidket/user/domain/exception/UserErrorCode.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/exception/UserErrorCode.java
@@ -41,6 +41,7 @@ public enum UserErrorCode {
     EMAIL_DUPLICATE(HttpStatus.CONFLICT, "EMAIL_DUPLICATE", "이미 사용 중인 이메일입니다."),
     LOGIN_ID_DUPLICATE(HttpStatus.CONFLICT, "LOGIN_ID_DUPLICATE", "이미 사용 중인 로그인 아이디입니다."),
     NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "NICKNAME_DUPLICATE", "이미 사용 중인 닉네임입니다."),
+    ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "ALREADY_WITHDRAWN", "이미 탈퇴한 회원입니다."),
     
     // 500 Internal Server Error
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR", "서버에서 오류가 발생했습니다. 다시 시도해주세요.");

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/RefreshToken.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/RefreshToken.java
@@ -26,7 +26,7 @@ public class RefreshToken extends BaseEntity {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "user_id", nullable = false, columnDefinition = "UUID")
+    @Column(name = "user_id", nullable = false)
     private UUID userId;
 
     @Column(name = "token", nullable = false, columnDefinition = "TEXT")
@@ -35,27 +35,15 @@ public class RefreshToken extends BaseEntity {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
-    @Column(name = "revoked", nullable = false)
-    private Boolean revoked;
-
     @Builder
-    public RefreshToken(UUID userId, String token, LocalDateTime expiresAt, Boolean revoked) {
+    public RefreshToken(UUID userId, String token, LocalDateTime expiresAt) {
         this.userId = userId;
         this.token = token;
         this.expiresAt = expiresAt;
-        this.revoked = revoked != null ? revoked : false;
     }
 
-    public void revoke() {
-        this.revoked = true;
-    }
-
-    public boolean isExpired() {
-        return LocalDateTime.now().isAfter(this.expiresAt);
-    }
-
-    public boolean isValid() {
-        return !this.revoked && !isExpired();
+    public boolean isExpired(LocalDateTime now) {
+        return now.isAfter(this.expiresAt);
     }
 }
 

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
@@ -61,6 +61,9 @@ public class User extends BaseEntity {
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
 
+    @Column(name = "deactivated_at")
+    private LocalDateTime deactivatedAt;
+
     @Builder
     public User(String loginId, Provider provider, String providerId, String name, 
                   String password, String email, String nickname, String phone, UserStatus status) {
@@ -115,6 +118,7 @@ public class User extends BaseEntity {
 
     public void withdraw() {
         this.status = UserStatus.WITHDRAWN;
+        this.deactivatedAt = LocalDateTime.now();
     }
 
     public boolean isLocalProvider() {

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/entity/User.java
@@ -85,6 +85,22 @@ public class User extends BaseEntity {
         this.phone = phone;
     }
 
+    /**
+     * 프로필 수정 (nickname, phone, email)
+     * 각 필드는 null이 아닌 경우에만 업데이트
+     */
+    public void updateProfileFields(String nickname, String phone, String email) {
+        if (nickname != null && !nickname.isBlank()) {
+            this.nickname = nickname;
+        }
+        if (phone != null && !phone.isBlank()) {
+            this.phone = phone;
+        }
+        if (email != null && !email.isBlank()) {
+            this.email = email;
+        }
+    }
+
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
     }

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/repository/RefreshTokenRepository.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/repository/RefreshTokenRepository.java
@@ -4,6 +4,7 @@ import com.bidket.user.infrastructure.persistence.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,8 +13,8 @@ import java.util.UUID;
  */
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    /** 사용자 ID로 리프레시 토큰 조회 */
-    Optional<RefreshToken> findByUserId(UUID userId);
+    /** 사용자 ID로 모든 리프레시 토큰 조회 */
+    List<RefreshToken> findAllByUserId(UUID userId);
     
     /** 토큰 문자열로 리프레시 토큰 조회 */
     Optional<RefreshToken> findByToken(String token);

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/repository/UserRepository.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/persistence/repository/UserRepository.java
@@ -26,5 +26,11 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     
     /** 닉네임 중복 확인 */
     boolean existsByNickname(String nickname);
+
+    /** 특정 회원을 제외하고 이메일 중복 확인 */
+    boolean existsByEmailAndIdNot(String email, UUID id);
+
+    /** 특정 회원을 제외하고 닉네임 중복 확인 */
+    boolean existsByNicknameAndIdNot(String nickname, UUID id);
 }
 

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
@@ -8,6 +8,7 @@ import com.bidket.user.application.service.BlacklistReleaseService;
 import com.bidket.user.application.service.BlacklistStatusService;
 import com.bidket.user.application.service.EmailCheckService;
 import com.bidket.user.application.service.LoginService;
+import com.bidket.user.application.service.LogoutService;
 import com.bidket.user.application.service.NicknameCheckService;
 import com.bidket.user.application.service.MyInfoService;
 import com.bidket.user.application.service.PermissionsService;
@@ -30,6 +31,7 @@ import com.bidket.user.presentation.dto.response.BlacklistReleaseResponse;
 import com.bidket.user.presentation.dto.response.BlacklistStatusResponse;
 import com.bidket.user.presentation.dto.response.EmailCheckResponse;
 import com.bidket.user.presentation.dto.response.LoginResponse;
+import com.bidket.user.presentation.dto.response.LogoutResponse;
 import com.bidket.user.presentation.dto.response.NicknameCheckResponse;
 import com.bidket.user.presentation.dto.response.MyInfoResponse;
 import com.bidket.user.presentation.dto.response.PermissionsResponse;
@@ -73,6 +75,7 @@ public class MemberController {
 
     private final SignupService signupService;
     private final LoginService loginService;
+    private final LogoutService logoutService;
     private final MyInfoService myInfoService;
     private final EmailCheckService emailCheckService;
     private final NicknameCheckService nicknameCheckService;
@@ -204,6 +207,37 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success("로그인에 성공했습니다.", response));
+    }
+
+    /**
+     * 로그아웃 API
+     * POST /v1/members/logout
+     * 현재 로그인 세션을 종료하고 Refresh Token을 무효화
+     * 멱등성 보장: 이미 로그아웃된 상태여도 동일하게 성공 응답을 반환
+     * @return 로그아웃 응답 (success)
+     */
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 로그인 세션을 종료하고 Refresh Token을 무효화합니다. Authorization 헤더(Bearer JWT 토큰)가 필수이며, 이를 통해 사용자를 식별하여 해당 사용자의 모든 Refresh Token을 무효화합니다. 멱등성 보장: 이미 로그아웃된 상태여도 성공 응답을 반환합니다.",
+            tags = {"01. 회원 인증"},
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 처리 완료(또는 이미 로그아웃 상태 포함)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Authorization 누락 또는 유효하지 않은 토큰"
+            )
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<LogoutResponse>> logout() {
+        LogoutResponse response = logoutService.logout();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success("로그아웃이 완료되었습니다.", response));
     }
 
     /**

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
@@ -13,9 +13,11 @@ import com.bidket.user.application.service.MyInfoService;
 import com.bidket.user.application.service.PermissionsService;
 import com.bidket.user.application.service.PointBalanceService;
 import com.bidket.user.application.service.PointHistoryService;
+import com.bidket.user.application.service.ProfileUpdateService;
 import com.bidket.user.application.service.SignupService;
 import com.bidket.user.presentation.dto.request.BlacklistRegisterRequest;
 import com.bidket.user.presentation.dto.request.LoginRequest;
+import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
 import com.bidket.user.presentation.dto.request.SignupRequest;
 import com.bidket.user.presentation.dto.response.BidEligibilityResponse;
 import com.bidket.user.presentation.dto.response.BlacklistListResponse;
@@ -29,6 +31,7 @@ import com.bidket.user.presentation.dto.response.MyInfoResponse;
 import com.bidket.user.presentation.dto.response.PermissionsResponse;
 import com.bidket.user.presentation.dto.response.PointBalanceResponse;
 import com.bidket.user.presentation.dto.response.PointHistoryResponse;
+import com.bidket.user.presentation.dto.response.ProfileUpdateResponse;
 import com.bidket.user.presentation.dto.response.SignupResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -43,6 +46,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -74,6 +78,7 @@ public class MemberController {
     private final BidEligibilityService bidEligibilityService;
     private final PointBalanceService pointBalanceService;
     private final PointHistoryService pointHistoryService;
+    private final ProfileUpdateService profileUpdateService;
 
     /**
      * 이메일 중복 체크 API
@@ -217,6 +222,45 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success("내 정보 조회에 성공했습니다.", response));
+    }
+
+    /**
+     * 프로필 수정 API
+     * @param request 프로필 수정 요청 정보 (nickname, phone, email 중 최소 1개 필수)
+     * @return 프로필 수정 응답 (userId, nickname, phone, email, updatedAt)
+     */
+    @Operation(
+            summary = "프로필 수정",
+            description = "현재 로그인한 사용자의 프로필 정보를 수정합니다. 최소 1개 필드는 포함되어야 합니다.",
+            tags = {"02. 회원 정보"},
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = ProfileUpdateResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (최소 1개 필드 미포함, 형식 오류 등)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "중복된 이메일 또는 닉네임"
+            )
+    })
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<ProfileUpdateResponse>> updateProfile(
+            @RequestBody @Valid ProfileUpdateRequest request) {
+        ProfileUpdateResponse response = profileUpdateService.updateProfile(request);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success("프로필 수정에 성공했습니다.", response));
     }
 
     /**

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
@@ -13,10 +13,12 @@ import com.bidket.user.application.service.MyInfoService;
 import com.bidket.user.application.service.PermissionsService;
 import com.bidket.user.application.service.PointBalanceService;
 import com.bidket.user.application.service.PointHistoryService;
+import com.bidket.user.application.service.PasswordChangeService;
 import com.bidket.user.application.service.ProfileUpdateService;
 import com.bidket.user.application.service.SignupService;
 import com.bidket.user.presentation.dto.request.BlacklistRegisterRequest;
 import com.bidket.user.presentation.dto.request.LoginRequest;
+import com.bidket.user.presentation.dto.request.PasswordChangeRequest;
 import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
 import com.bidket.user.presentation.dto.request.SignupRequest;
 import com.bidket.user.presentation.dto.response.BidEligibilityResponse;
@@ -30,6 +32,7 @@ import com.bidket.user.presentation.dto.response.NicknameCheckResponse;
 import com.bidket.user.presentation.dto.response.MyInfoResponse;
 import com.bidket.user.presentation.dto.response.PermissionsResponse;
 import com.bidket.user.presentation.dto.response.PointBalanceResponse;
+import com.bidket.user.presentation.dto.response.PasswordChangeResponse;
 import com.bidket.user.presentation.dto.response.PointHistoryResponse;
 import com.bidket.user.presentation.dto.response.ProfileUpdateResponse;
 import com.bidket.user.presentation.dto.response.SignupResponse;
@@ -79,6 +82,7 @@ public class MemberController {
     private final PointBalanceService pointBalanceService;
     private final PointHistoryService pointHistoryService;
     private final ProfileUpdateService profileUpdateService;
+    private final PasswordChangeService passwordChangeService;
 
     /**
      * 이메일 중복 체크 API
@@ -164,7 +168,7 @@ public class MemberController {
             )
     })
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody @Valid SignupRequest request) {
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody(required = true) @Valid SignupRequest request) {
         SignupResponse response = signupService.signup(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
@@ -191,7 +195,7 @@ public class MemberController {
             )
     })
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody(required = true) @Valid LoginRequest request) {
         LoginResponse response = loginService.login(request);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -256,11 +260,46 @@ public class MemberController {
     })
     @PatchMapping("/profile")
     public ResponseEntity<ApiResponse<ProfileUpdateResponse>> updateProfile(
-            @RequestBody @Valid ProfileUpdateRequest request) {
+            @RequestBody(required = true) @Valid ProfileUpdateRequest request) {
         ProfileUpdateResponse response = profileUpdateService.updateProfile(request);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success("프로필 수정에 성공했습니다.", response));
+    }
+
+    /**
+     * 비밀번호 변경 API
+     * @param request 비밀번호 변경 요청 정보 (currentPassword, newPassword)
+     * @return 비밀번호 변경 응답 (success, changedAt)
+     */
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "현재 로그인한 사용자의 비밀번호를 변경합니다.",
+            tags = {"02. 회원 정보"},
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 변경 성공",
+                    content = @Content(schema = @Schema(implementation = PasswordChangeResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (현재 비밀번호 불일치, 비밀번호 강도 부족, 새 비밀번호가 현재 비밀번호와 동일 등)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요 (토큰 누락/만료/위조 등)"
+            )
+    })
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<PasswordChangeResponse>> changePassword(
+            @RequestBody(required = true) @Valid PasswordChangeRequest request) {
+        PasswordChangeResponse response = passwordChangeService.changePassword(request);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success("비밀번호 변경에 성공했습니다.", response));
     }
 
     /**
@@ -326,7 +365,7 @@ public class MemberController {
     @PostMapping("/{memberId}/blacklist")
     public ResponseEntity<BlacklistRegisterResponse> registerBlacklist(
             @PathVariable UUID memberId,
-            @RequestBody @Valid BlacklistRegisterRequest request) {
+            @RequestBody(required = true) @Valid BlacklistRegisterRequest request) {
         BlacklistRegisterResponse response = blacklistRegisterService.registerBlacklist(memberId, request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
@@ -13,11 +13,13 @@ import com.bidket.user.application.service.MyInfoService;
 import com.bidket.user.application.service.PermissionsService;
 import com.bidket.user.application.service.PointBalanceService;
 import com.bidket.user.application.service.PointHistoryService;
+import com.bidket.user.application.service.MemberDeactivationService;
 import com.bidket.user.application.service.PasswordChangeService;
 import com.bidket.user.application.service.ProfileUpdateService;
 import com.bidket.user.application.service.SignupService;
 import com.bidket.user.presentation.dto.request.BlacklistRegisterRequest;
 import com.bidket.user.presentation.dto.request.LoginRequest;
+import com.bidket.user.presentation.dto.request.MemberDeactivationRequest;
 import com.bidket.user.presentation.dto.request.PasswordChangeRequest;
 import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
 import com.bidket.user.presentation.dto.request.SignupRequest;
@@ -32,6 +34,7 @@ import com.bidket.user.presentation.dto.response.NicknameCheckResponse;
 import com.bidket.user.presentation.dto.response.MyInfoResponse;
 import com.bidket.user.presentation.dto.response.PermissionsResponse;
 import com.bidket.user.presentation.dto.response.PointBalanceResponse;
+import com.bidket.user.presentation.dto.response.MemberDeactivationResponse;
 import com.bidket.user.presentation.dto.response.PasswordChangeResponse;
 import com.bidket.user.presentation.dto.response.PointHistoryResponse;
 import com.bidket.user.presentation.dto.response.ProfileUpdateResponse;
@@ -83,6 +86,7 @@ public class MemberController {
     private final PointHistoryService pointHistoryService;
     private final ProfileUpdateService profileUpdateService;
     private final PasswordChangeService passwordChangeService;
+    private final MemberDeactivationService memberDeactivationService;
 
     /**
      * 이메일 중복 체크 API
@@ -300,6 +304,51 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success("비밀번호 변경에 성공했습니다.", response));
+    }
+
+    /**
+     * 회원 탈퇴(비활성화) API
+     * DELETE /v1/members/me
+     * @param request 회원 탈퇴 요청 정보 (reason - 선택사항)
+     * @return 회원 탈퇴 응답 (memberId, status, deactivatedAt)
+     */
+    @Operation(
+            summary = "회원 탈퇴(비활성화)",
+            description = "현재 로그인한 사용자의 계정을 비활성화 처리합니다. 논리삭제 방식으로 데이터는 유지되며, 탈퇴 후 모든 기능이 제한됩니다.",
+            tags = {"02. 회원 정보"},
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(schema = @Schema(implementation = MemberDeactivationResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요 (토큰 누락/만료/위조 등)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 탈퇴한 사용자"
+            )
+    })
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<MemberDeactivationResponse>> deactivateMember(
+            @RequestBody(required = false) MemberDeactivationRequest request) {
+        // request가 null인 경우 빈 객체로 처리
+        MemberDeactivationRequest deactivationRequest = request != null 
+                ? request 
+                : new MemberDeactivationRequest(null);
+        
+        MemberDeactivationResponse response = memberDeactivationService.deactivateMember(deactivationRequest);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success("회원 탈퇴가 완료되었습니다.", response));
     }
 
     /**

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/MemberDeactivationRequest.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/MemberDeactivationRequest.java
@@ -1,0 +1,15 @@
+package com.bidket.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 회원 탈퇴(비활성화) 요청 DTO
+ */
+@Schema(description = "회원 탈퇴(비활성화) 요청")
+public record MemberDeactivationRequest(
+        /** 탈퇴(비활성화) 사유 (설문/통계용) */
+        @Schema(description = "탈퇴(비활성화) 사유 (설문/통계용)", example = "서비스를 더 이상 사용하지 않음")
+        String reason
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/PasswordChangeRequest.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,22 @@
+package com.bidket.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 비밀번호 변경 요청 DTO
+ */
+@Schema(description = "비밀번호 변경 요청")
+public record PasswordChangeRequest(
+        /** 기존 비밀번호 */
+        @NotBlank(message = "기존 비밀번호는 필수입니다.")
+        @Schema(description = "기존 비밀번호", requiredMode = Schema.RequiredMode.REQUIRED)
+        String currentPassword,
+
+        /** 새 비밀번호 */
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Schema(description = "새 비밀번호", requiredMode = Schema.RequiredMode.REQUIRED)
+        String newPassword
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/ProfileUpdateRequest.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,42 @@
+package com.bidket.user.presentation.dto.request;
+
+import com.bidket.user.presentation.dto.request.validation.AtLeastOneField;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로필 수정 요청 DTO
+ * 최소 1개 필드는 포함되어야 함 (nickname / phone / email 중 택1 이상)
+ */
+@AtLeastOneField
+@Schema(description = "프로필 수정 요청")
+public record ProfileUpdateRequest(
+        /** 변경할 닉네임 */
+        @Size(max = 100, message = "닉네임은 100자 이하여야 합니다.")
+        @Schema(description = "변경할 닉네임", example = "콘서트대장")
+        String nickname,
+
+        /** 변경할 전화번호 (하이픈, 공백 포함 가능, 서버에서 하이픈과 공백 제거 후 저장) */
+        @Pattern(regexp = "^[0-9]+([-\\s][0-9]+)*$", message = "전화번호는 숫자로 시작해야 하며, 하이픈, 공백, 숫자 조합만 허용됩니다.")
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다.")
+        @Schema(description = "변경할 전화번호 (하이픈, 공백 포함 가능, 서버에서 하이픈과 공백 제거 후 저장)", example = "01012345678")
+        String phone,
+
+        /** 변경할 이메일 */
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Size(max = 255, message = "이메일은 255자 이하여야 합니다.")
+        @Schema(description = "변경할 이메일", example = "newmail@example.com")
+        String email
+) {
+    /**
+     * 최소 1개 필드가 포함되어야 함
+     */
+    public boolean hasAtLeastOneField() {
+        return (nickname != null && !nickname.isBlank()) ||
+               (phone != null && !phone.isBlank()) ||
+               (email != null && !email.isBlank());
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneField.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneField.java
@@ -1,0 +1,24 @@
+package com.bidket.user.presentation.dto.request.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 최소 1개 필드가 포함되어야 함을 검증하는 어노테이션
+ */
+@Documented
+@Constraint(validatedBy = AtLeastOneFieldValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AtLeastOneField {
+    String message() default "최소 1개 필드는 포함되어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneFieldValidator.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/request/validation/AtLeastOneFieldValidator.java
@@ -1,0 +1,36 @@
+package com.bidket.user.presentation.dto.request.validation;
+
+import com.bidket.user.presentation.dto.request.ProfileUpdateRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/*
+ * 최소 1개 필드 포함 검증 Validator
+ */
+public class AtLeastOneFieldValidator implements ConstraintValidator<AtLeastOneField, ProfileUpdateRequest> {
+
+    @Override
+    public void initialize(AtLeastOneField constraintAnnotation) {
+        // 초기화 로직이 필요한 경우 여기에 작성
+    }
+
+    @Override
+    public boolean isValid(ProfileUpdateRequest request, ConstraintValidatorContext context) {
+        if (request == null) {
+            return false;
+        }
+
+        // ProfileUpdateRequest의 hasAtLeastOneField() 메서드를 직접 호출
+        boolean isValid = request.hasAtLeastOneField();
+
+        if (!isValid) {
+            // 커스텀 에러 메시지 설정
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("최소 1개 필드는 포함되어야 합니다. (nickname, phone, email 중 택1 이상)")
+                    .addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/LogoutResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/LogoutResponse.java
@@ -1,0 +1,15 @@
+package com.bidket.user.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 로그아웃 응답 DTO
+ */
+@Schema(description = "로그아웃 응답")
+public record LogoutResponse(
+        /** 로그아웃 처리 성공 여부 */
+        @Schema(description = "로그아웃 처리 성공 여부", example = "true")
+        boolean success
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/MemberDeactivationResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/MemberDeactivationResponse.java
@@ -1,0 +1,29 @@
+package com.bidket.user.presentation.dto.response;
+
+import com.bidket.user.domain.model.UserStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 회원 탈퇴(비활성화) 응답 DTO
+ */
+@Builder
+@Schema(description = "회원 탈퇴(비활성화) 응답")
+public record MemberDeactivationResponse(
+        /** 비활성화된 회원 ID */
+        @Schema(description = "비활성화된 회원 ID", example = "c12f92cd-7a6e-4c92-ae01-e77ca1cafe56")
+        UUID memberId,
+
+        /** 변경된 상태 */
+        @Schema(description = "변경된 상태", example = "WITHDRAWN")
+        UserStatus status,
+
+        /** 비활성화 처리 일시 */
+        @Schema(description = "비활성화 처리 일시", example = "2025-11-27T13:00:00", type = "string", format = "date-time")
+        LocalDateTime deactivatedAt
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/PasswordChangeResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/PasswordChangeResponse.java
@@ -1,0 +1,23 @@
+package com.bidket.user.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 비밀번호 변경 응답 DTO
+ */
+@Builder
+@Schema(description = "비밀번호 변경 응답")
+public record PasswordChangeResponse(
+        /** 비밀번호 변경 성공 여부 */
+        @Schema(description = "비밀번호 변경 성공 여부", example = "true")
+        boolean success,
+
+        /** 비밀번호 변경 시각 */
+        @Schema(description = "비밀번호 변경 시각", example = "2025-11-27T12:10:00", type = "string", format = "date-time")
+        LocalDateTime changedAt
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/ProfileUpdateResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/ProfileUpdateResponse.java
@@ -1,0 +1,36 @@
+package com.bidket.user.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 프로필 수정 응답 DTO
+ */
+@Builder
+@Schema(description = "프로필 수정 응답")
+public record ProfileUpdateResponse(
+        /** 회원 ID (UUID) */
+        @Schema(description = "회원 ID", example = "c12f92cd-7a6e-4c92-ae01-e77ca1cafe56")
+        UUID userId,
+
+        /** 변경 후 닉네임 */
+        @Schema(description = "변경 후 닉네임", example = "콘서트대장")
+        String nickname,
+
+        /** 변경 후 전화번호 (미변경/미보유면 null 가능) */
+        @Schema(description = "변경 후 전화번호", example = "01012345678", nullable = true)
+        String phone,
+
+        /** 변경 후 이메일 (미변경/미보유면 null 가능) */
+        @Schema(description = "변경 후 이메일", example = "newmail@example.com", nullable = true)
+        String email,
+
+        /** 수정 시각 */
+        @Schema(description = "수정 시각", example = "2025-11-27T12:10:00", type = "string", format = "date-time")
+        LocalDateTime updatedAt
+) {
+}
+


### PR DESCRIPTION
## Issue Number
- closed #[issue-number]

## Description
- Logout DTO 생성
-RefreshTokenRepository 확장
-LogoutService 생성
-MemberController에 POST 엔드포인트 추가

## Test Result
<img width="647" height="351" alt="image" src="https://github.com/user-attachments/assets/7a2cb965-86ef-472a-a691-6b4269bf5ec1" />

## To Reviewer
로그아웃 API 구현 완료했습니다.
현재 구조상 로그아웃은 userId 기준 Refresh Token 전체 삭제로 동작합니다.
다만 현재 로그인 시 Refresh Token을 DB에 저장하는 로직이 아직 구현되지 않아,
로그아웃 시 RT 삭제 동작은 실제 데이터 기준으로 테스트하지 못한 상태입니다.
Refresh Token DB 저장 로직 구현 후,
로그인 → 로그아웃 흐름으로 재테스트 및 보완 예정입니다.
