### PR TITLE
feat: 게이트웨이 스웨거 설정 추가

### DIFF
--- a/backend/gateway-service/src/main/java/com/bidket/gateway/config/OpenApiConfig.java
+++ b/backend/gateway-service/src/main/java/com/bidket/gateway/config/OpenApiConfig.java
@@ -1,0 +1,44 @@
+package com.bidket.gateway.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        String jwtSchemeName = "Bearer Authentication";
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Bidket Gateway API Dashboard")
+                        .description(
+                                "### 신발 입찰/경매 대기열 처리 플랫폼 \n"
+                                + "----------------------------------------- \n"
+                                + "Bidket 서비스의 모든 마이크로서비스 API를 통합 제공하는 게이트웨이 대시보드입니다.<br>"
+                                + "우측 상단의 **[Select a definition]** 드롭박스를 클릭하여 각 마이크로서비스의 상세 API 명세를 확인하실 수 있습니다."
+                        )
+                        .version("v1")
+                        .contact(new Contact()
+                                .name("🔗 Team Bidket Github")
+                                .url("https://github.com/Bidket/bidket-project")))
+
+                // 모든 API에 보안 요구사항 추가
+                .addSecurityItem(new SecurityRequirement().addList(jwtSchemeName))
+
+                // JWT 보안 스키마 정의
+                .components(new Components()
+                        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                                .name(jwtSchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("발급받은 JWT 토큰을 입력하세요. (Bearer는 자동으로 붙습니다)")));
+    }
+}

--- a/backend/gateway-service/src/main/resources/application.yml
+++ b/backend/gateway-service/src/main/resources/application.yml
@@ -21,6 +21,39 @@ spring:
           enabled: true
           lower-case-service-id: true
 
+springdoc:
+  enable-native-support: true
+  swagger-ui:
+    # 기본 URL(/v3/api-docs)이 리스트를 덮어쓰지 못하게 방지
+    disable-swagger-default-url: true
+
+    # 내부 API 가독성 위한 정렬 옵션
+    tags-sorter: alpha # 컨트롤러 정렬
+    operations-sorter: alpha # API 경로 정렬
+
+    # 드롭다운 메뉴 구성
+    urls:
+      - name: "00. Bidket Gateway API Dashboard"
+        url: /v3/api-docs
+      - name: "01. User-Service"
+        url: /user-service/v3/api-docs
+      - name: "02. Order-Service"
+        url: /order-service/v3/api-docs
+      - name: "03. Product-Service"
+        url: /product-service/v3/api-docs
+      - name: "04. Auction-Service"
+        url: /auction-service/v3/api-docs
+      - name: "05. Queue-Service"
+        url: /queue-service/v3/api-docs
+      - name: "06. Notification-Service"
+        url: /notification-service/v3/api-docs
+
+    # 처음 접속 시 API 리스트 형태로 보여줌
+    doc-expansion: list
+
+    # API 호출 시 응답 시간 표시
+    display-request-duration: true
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## Issue Number
- closed #159

## Description
  - OpenApiConfig 추가
  - appilcation.yml에 springdoc 설정 추가
    - 라우팅 기존 discoveory 방식 사용
  - 모든 서비스에서 게이트웨이와 동일한 이름의 jwtSchemeName을 가진 OpenApiConfig 설정이 있어야 같은 토큰값을 연속적으로 서비스간에 사용할 수 있습니다.
- jwtSchemeName 값은 유저 서비스 OpenApiConfig 설정의 동일한 name값을 사용했습니다.
- 만약 퍼블릭 API에 자물쇠 아이콘이 뜨지 않길 원한다면 해당 API에 @SecurityRequirements 설정을 하면 사라집니다. (자물쇠 아이콘이 있더라도 퍼블릭 API로 구현했다면 값 없이 요청시 정상 동작함)


## Test Result
- 접속시 대시보드 
<img width="1877" height="893" alt="image" src="https://github.com/user-attachments/assets/b7d7cd52-7d06-4582-8b76-c4c0e9f3f92b" />

- 서비스 목록
<img width="772" height="391" alt="image" src="https://github.com/user-attachments/assets/d69fc22f-02e9-4359-a68a-79927eac13b3" />

- authorize 버튼
<img width="1059" height="527" alt="image" src="https://github.com/user-attachments/assets/e29019b8-e67a-49cd-9ed7-ead544abc10a" />


## To Reviewer
- 로컬 호출 주소: http://localhost:8000/swagger-ui.html
- 서버 호출 주소: http://3.38.145.104:8000/swagger-ui.html

