### PR TITLE
feat: 회원 입찰/주문 히스토리 조회 API 구현(#165)

### DIFF
--- a/backend/user-service/src/main/java/com/bidket/user/application/service/HistoryService.java
+++ b/backend/user-service/src/main/java/com/bidket/user/application/service/HistoryService.java
@@ -1,0 +1,201 @@
+package com.bidket.user.application.service;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.bidket.user.global.security.AuthenticationHelper;
+import com.bidket.user.infrastructure.external.AuctionServiceClient;
+import com.bidket.user.infrastructure.external.OrderServiceClient;
+import com.bidket.user.presentation.dto.response.BidHistoryItemResponse;
+import com.bidket.user.presentation.dto.response.BidHistoryResponse;
+import com.bidket.user.presentation.dto.response.OrderHistoryItemResponse;
+import com.bidket.user.presentation.dto.response.OrderHistoryResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 입찰/주문 내역 조회 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final AuctionServiceClient auctionServiceClient;
+    private final OrderServiceClient orderServiceClient;
+
+    /**
+     * 입찰/주문 내역 조회
+     * @param page 페이지 번호 (0부터 시작, 기본값 0)
+     * @param size 페이지 사이즈 (기본값 20)
+     * @param type 히스토리 타입 (BID 또는 ORDER, 기본값 BID)
+     * @param authorizationToken Authorization 헤더 값 (Bearer 토큰)
+     * @return 입찰/주문 내역 조회 응답 (타입에 따라 BidHistoryResponse 또는 OrderHistoryResponse)
+     */
+    public Object getHistory(Integer page, Integer size, String type, String authorizationToken) {
+        UUID userId = AuthenticationHelper.getCurrentUserId();
+        
+        // 검증: page는 0 이상이어야 함
+        if (page != null && page < 0) {
+            throw new UserException(UserErrorCode.BAD_REQUEST);
+        }
+        
+        // 검증: size는 1 이상 100 이하여야 함
+        if (size != null && (size < 1 || size > 100)) {
+            throw new UserException(UserErrorCode.BAD_REQUEST);
+        }
+        
+        // 기본값 설정
+        int pageNum = (page != null && page >= 0) ? page : 0;
+        int pageSize = (size != null && size > 0) ? size : 20;
+        String historyType = (type != null && !type.isEmpty()) ? type : "BID";
+        
+        log.info("입찰/주문 내역 조회 요청: userId={}, type={}, page={}, size={}", userId, historyType, pageNum, pageSize);
+        
+        if ("BID".equalsIgnoreCase(historyType)) {
+            return getBidHistory(userId, pageNum, pageSize, authorizationToken);
+        } else if ("ORDER".equalsIgnoreCase(historyType)) {
+            return getOrderHistory(userId, pageNum, pageSize, authorizationToken);
+        } else {
+            throw new UserException(UserErrorCode.INVALID_HISTORY_TYPE);
+        }
+    }
+
+    /**
+     * 입찰 내역 조회
+     */
+    private BidHistoryResponse getBidHistory(UUID userId, int page, int size, String authorizationToken) {
+        try {
+            AuctionServiceClient.BidListResponse bidListResponse = 
+                    auctionServiceClient.getMyBids(userId, authorizationToken);
+            
+            List<AuctionServiceClient.BidResponse> bids = bidListResponse.getBids();
+            
+            // 페이징 처리
+            int start = page * size;
+            int end = Math.min(start + size, bids.size());
+            List<AuctionServiceClient.BidResponse> pagedBids = 
+                    start < bids.size() ? bids.subList(start, end) : List.of();
+            
+            // BidResponse를 BidHistoryItemResponse로 변환
+            List<BidHistoryItemResponse> historyItems = pagedBids.stream()
+                    .map(this::convertBidToHistoryItem)
+                    .collect(Collectors.toList());
+            
+            long totalElements = bidListResponse.getTotalCount() != null ? bidListResponse.getTotalCount() : (long) bids.size();
+            int totalPages = (int) Math.ceil((double) totalElements / size);
+            
+            return new BidHistoryResponse(
+                    historyItems,
+                    totalElements,
+                    totalPages,
+                    page,
+                    size
+            );
+                    
+        } catch (UserException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("입찰 내역 조회 실패: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.AUCTION_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("입찰 내역 조회 중 예상치 못한 오류: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 주문 내역 조회
+     */
+    private OrderHistoryResponse getOrderHistory(UUID userId, int page, int size, String authorizationToken) {
+        try {
+            com.bidket.common.presentation.response.PageResponse<OrderServiceClient.OrderSummaryResponse> orderPage = 
+                    orderServiceClient.getOrders(userId, page, size, authorizationToken);
+            
+            if (orderPage == null || orderPage.getContent() == null) {
+                return new OrderHistoryResponse(
+                        page,
+                        size,
+                        0L,
+                        0,
+                        false,
+                        false,
+                        List.of()
+                );
+            }
+            
+            // OrderSummaryResponse를 OrderHistoryItemResponse로 변환
+            List<OrderHistoryItemResponse> historyItems = orderPage.getContent().stream()
+                    .map(this::convertOrderToHistoryItem)
+                    .collect(Collectors.toList());
+            
+            long totalElements = orderPage.getTotalElements();
+            int totalPages = orderPage.getTotalPages();
+            boolean hasNext = page < totalPages - 1;
+            boolean hasPrevious = page > 0;
+            
+            return new OrderHistoryResponse(
+                    page,
+                    size,
+                    totalElements,
+                    totalPages,
+                    hasNext,
+                    hasPrevious,
+                    historyItems
+            );
+                    
+        } catch (UserException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("주문 내역 조회 실패: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.ORDER_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("주문 내역 조회 중 예상치 못한 오류: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.SERVER_ERROR);
+        }
+    }
+
+    /**
+     * BidResponse를 BidHistoryItemResponse로 변환
+     */
+    private BidHistoryItemResponse convertBidToHistoryItem(
+            AuctionServiceClient.BidResponse bid) {
+        
+        // auction-service의 BidResponse를 그대로 BidHistoryItemResponse로 변환
+        return BidHistoryItemResponse.builder()
+                .id(bid.getId())
+                .auctionId(bid.getAuctionId())
+                .bidderId(bid.getBidderId())
+                .amount(bid.getAmount())
+                .highest(bid.getHighest())
+                .status(bid.getStatus())
+                .rank(bid.getRank())
+                .orderId(bid.getOrderId())
+                .createdAt(bid.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * OrderSummaryResponse를 OrderHistoryItemResponse로 변환
+     */
+    private OrderHistoryItemResponse convertOrderToHistoryItem(
+            OrderServiceClient.OrderSummaryResponse order) {
+        
+        // order-service의 OrderSummaryResponse를 그대로 OrderHistoryItemResponse로 변환
+        return OrderHistoryItemResponse.builder()
+                .orderId(UUID.fromString(order.getOrderId()))
+                .status(order.getStatus())
+                .amount(order.getAmount())
+                .productName(order.getProductName())
+                .auctionTitle(order.getAuctionTitle())
+                .auctionStartTime(order.getAuctionStartTime())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/domain/exception/UserErrorCode.java
+++ b/backend/user-service/src/main/java/com/bidket/user/domain/exception/UserErrorCode.java
@@ -12,29 +12,30 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode {
     // 400 Bad Request
     TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERMS_NOT_AGREED", "이용약관에 동의해야 합니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."), // 일반적인 잘못된 요청
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "입력값 검증에 실패했습니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "잘못된 이메일 형식입니다."),
     WEAK_PASSWORD(HttpStatus.BAD_REQUEST, "WEAK_PASSWORD", "비밀번호 강도가 부족합니다."),
     PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PASSWORD_CHANGE_NOT_ALLOWED", "소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다."),
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_CURRENT_PASSWORD", "현재 비밀번호가 올바르지 않습니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "provider와 인증 토큰(idToken)을 확인해주세요."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "provider와 인증 토큰(idToken)을 확인해주세요."), // 소셜 로그인 인증 관련
     
     // 401 Unauthorized
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "토큰이 만료되었습니다."),
-    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."), // 인증 과정에서 사용자 조회 실패 시 사용
     SOCIAL_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "SOCIAL_TOKEN_INVALID", "소셜 인증 토큰이 유효하지 않습니다."),
     
     // 403 Forbidden
     INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "INACTIVE_MEMBER", "비활성화된 계정입니다."),
     BLACKLISTED_MEMBER(HttpStatus.FORBIDDEN, "BLACKLISTED_MEMBER", "블랙리스트 회원으로 로그인할 수 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
     
     // 404 Not Found
     BLACKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "BLACKLIST_NOT_FOUND", "블랙리스트를 찾을 수 없습니다."),
-    BLACKLIST_ALREADY_RELEASED(HttpStatus.CONFLICT, "BLACKLIST_ALREADY_RELEASED", "이미 해제된 블랙리스트입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
     
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "이 요청 방식은 허용되지 않습니다."),
@@ -44,9 +45,15 @@ public enum UserErrorCode {
     LOGIN_ID_DUPLICATE(HttpStatus.CONFLICT, "LOGIN_ID_DUPLICATE", "이미 사용 중인 로그인 아이디입니다."),
     NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "NICKNAME_DUPLICATE", "이미 사용 중인 닉네임입니다."),
     ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "ALREADY_WITHDRAWN", "이미 탈퇴한 회원입니다."),
+    BLACKLIST_ALREADY_RELEASED(HttpStatus.CONFLICT, "BLACKLIST_ALREADY_RELEASED", "이미 해제된 블랙리스트입니다."),
     
     // 500 Internal Server Error
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR", "서버에서 오류가 발생했습니다. 다시 시도해주세요.");
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR", "서버에서 오류가 발생했습니다. 다시 시도해주세요."),
+    
+    // 외부 서비스 관련 에러
+    INVALID_HISTORY_TYPE(HttpStatus.BAD_REQUEST, "INVALID_HISTORY_TYPE", "지원하지 않는 히스토리 타입입니다. BID 또는 ORDER만 가능합니다."),
+    AUCTION_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AUCTION_SERVICE_UNAVAILABLE", "경매 서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요."),
+    ORDER_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "ORDER_SERVICE_UNAVAILABLE", "주문 서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/backend/user-service/src/main/java/com/bidket/user/global/security/AuthorizationTokenValidator.java
+++ b/backend/user-service/src/main/java/com/bidket/user/global/security/AuthorizationTokenValidator.java
@@ -1,0 +1,50 @@
+package com.bidket.user.global.security;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Locale;
+
+/**
+ * Authorization 헤더 검증 및 정규화 유틸리티
+ * 검증과 전송에 동일한 정규화된 값을 사용하여 일관성 보장
+ */
+@Slf4j
+public class AuthorizationTokenValidator {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    /**
+     * Authorization 토큰 검증 및 정규화 (Bearer 형식 보장)
+     * 검증과 전송에 동일한 정규화된 값을 사용하여 일관성 보장
+     * @param authorizationToken 원본 Authorization 헤더 값
+     * @return 정규화된 Authorization 헤더 값 (Bearer + 토큰)
+     * @throws UserException 형식이 올바르지 않은 경우
+     */
+    public static String validateAndNormalize(String authorizationToken) {
+        if (authorizationToken == null || authorizationToken.isBlank()) {
+            throw new UserException(UserErrorCode.UNAUTHORIZED);
+        }
+
+        // trim으로 앞뒤 공백 제거
+        String trimmed = authorizationToken.trim();
+
+        // Bearer 형식 검증 (대소문자 구분 없이 체크, Locale.ROOT 사용하여 로케일 영향 방지)
+        if (!trimmed.toLowerCase(Locale.ROOT).startsWith("bearer ")) {
+            log.warn("Authorization 헤더 형식 오류: Bearer 형식이 아님");
+            throw new UserException(UserErrorCode.UNAUTHORIZED);
+        }
+
+        // 정규화: "Bearer " + 토큰 (앞뒤 공백 제거된 토큰)
+        // 토큰 추출: "bearer " (7자) 이후 부분 추출
+        String token = trimmed.substring(BEARER_PREFIX.length()).trim();
+        if (token.isBlank()) {
+            log.warn("Authorization 헤더 형식 오류: 토큰이 비어있음");
+            throw new UserException(UserErrorCode.UNAUTHORIZED);
+        }
+
+        return BEARER_PREFIX + token;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/external/AuctionServiceClient.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/external/AuctionServiceClient.java
@@ -1,0 +1,156 @@
+package com.bidket.user.infrastructure.external;
+
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Auction Service 클라이언트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionServiceClient {
+
+    private final RestClient restClient;
+    private final DiscoveryClient discoveryClient;
+
+    @Value("${spring.cloud.discovery.enabled:true}")
+    private boolean discoveryEnabled;
+
+    @Value("${services.auction-service.name:auction-service}")
+    private String auctionServiceName;
+
+    @Value("${services.auction-service.url:http://localhost:8300}")
+    private String auctionServiceUrl;
+
+    /**
+     * 내 입찰 내역 조회
+     * @param userId 사용자 ID
+     * @param authorizationToken Authorization 헤더 값 (Bearer 토큰)
+     * @return 입찰 내역 응답
+     */
+    public BidListResponse getMyBids(UUID userId, String authorizationToken) {
+        try {
+            String baseUrl = getBaseUrl();
+            String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                    .path("/api/v1/bids/my")
+                    .toUriString();
+
+            log.debug("Auction Service 호출: GET {}", url);
+
+            ParameterizedTypeReference<ApiResponseWrapper<BidListResponse>> responseType = 
+                    new ParameterizedTypeReference<ApiResponseWrapper<BidListResponse>>() {};
+
+            ApiResponseWrapper<BidListResponse> response = restClient.get()
+                    .uri(url)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationToken)
+                    .header("X-User-Id", userId.toString())
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        log.warn("Auction Service 호출 실패: userId={}, status={}", userId, res.getStatusCode());
+                        throw new UserException(UserErrorCode.BAD_REQUEST);
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                        log.error("Auction Service 호출 실패: userId={}, status={}", userId, res.getStatusCode());
+                        throw new UserException(UserErrorCode.AUCTION_SERVICE_UNAVAILABLE);
+                    })
+                    .body(responseType);
+
+            if (response == null || response.getData() == null) {
+                log.warn("Auction Service 응답 데이터 없음: userId={}", userId);
+                throw new UserException(UserErrorCode.AUCTION_SERVICE_UNAVAILABLE);
+            }
+            
+            return response.getData();
+
+        } catch (UserException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("Auction Service 호출 실패: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.AUCTION_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("Auction Service 호출 실패: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.AUCTION_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * 서비스 기본 URL 조회
+     */
+    private String getBaseUrl() {
+        if (discoveryEnabled) {
+            try {
+                ServiceInstance instance = discoveryClient.getInstances(auctionServiceName)
+                        .stream()
+                        .findFirst()
+                        .orElse(null);
+
+                if (instance != null) {
+                    return instance.getUri().toString();
+                }
+            } catch (Exception e) {
+                log.warn("Eureka에서 Auction Service 인스턴스를 찾을 수 없습니다: {}", e.getMessage());
+            }
+        }
+        return auctionServiceUrl;
+    }
+
+    /**
+     * ApiResponse 래퍼 DTO (역직렬화 문제 해결용)
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ApiResponseWrapper<T> {
+        @JsonProperty("data")
+        private T data;
+    }
+
+    /**
+     * 입찰 내역 응답 DTO
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BidListResponse {
+        private List<BidResponse> bids;
+        private Long totalCount;
+        private Integer currentPage;
+        private Integer totalPages;
+    }
+
+    /**
+     * 입찰 응답 DTO
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BidResponse {
+        private UUID id;
+        private UUID auctionId;
+        private UUID bidderId;
+        private Long amount;
+        private Boolean highest;
+        private String status;
+        private Integer rank;
+        private UUID orderId;
+        private LocalDateTime createdAt;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/infrastructure/external/OrderServiceClient.java
+++ b/backend/user-service/src/main/java/com/bidket/user/infrastructure/external/OrderServiceClient.java
@@ -1,0 +1,204 @@
+package com.bidket.user.infrastructure.external;
+
+import com.bidket.common.presentation.response.PageResponse;
+import com.bidket.user.domain.exception.UserErrorCode;
+import com.bidket.user.domain.exception.UserException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Order Service 클라이언트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderServiceClient {
+
+    private final RestClient restClient;
+    private final DiscoveryClient discoveryClient;
+
+    @Value("${spring.cloud.discovery.enabled:true}")
+    private boolean discoveryEnabled;
+
+    @Value("${services.order-service.name:order-service}")
+    private String orderServiceName;
+
+    @Value("${services.order-service.url:http://localhost:8500}")
+    private String orderServiceUrl;
+
+    /**
+     * 내 주문/결제 내역 조회
+     * @param userId 사용자 ID
+     * @param page 페이지 번호
+     * @param size 페이지 사이즈
+     * @param authorizationToken Authorization 헤더 값 (Bearer 토큰)
+     * @return 주문 내역 응답
+     */
+    public PageResponse<OrderSummaryResponse> getOrders(UUID userId, int page, int size, String authorizationToken) {
+        try {
+            String baseUrl = getBaseUrl();
+            String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                    .path("/v1/orders")
+                    .queryParam("userId", userId)
+                    .queryParam("page", page)
+                    .queryParam("size", size)
+                    .toUriString();
+
+            log.debug("Order Service 호출: GET {}", url);
+
+            ParameterizedTypeReference<ApiResponseWrapper<PageResponseWrapper<OrderSummaryResponse>>> responseType = 
+                    new ParameterizedTypeReference<ApiResponseWrapper<PageResponseWrapper<OrderSummaryResponse>>>() {};
+
+            ApiResponseWrapper<PageResponseWrapper<OrderSummaryResponse>> response = restClient.get()
+                    .uri(url)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        log.warn("Order Service 호출 실패: userId={}, status={}", userId, res.getStatusCode());
+                        throw new UserException(UserErrorCode.BAD_REQUEST);
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                        log.error("Order Service 호출 실패: userId={}, status={}", userId, res.getStatusCode());
+                        throw new UserException(UserErrorCode.ORDER_SERVICE_UNAVAILABLE);
+                    })
+                    .body(responseType);
+
+            if (response == null || response.getData() == null) {
+                log.warn("Order Service 응답 데이터 없음: userId={}", userId);
+                throw new UserException(UserErrorCode.ORDER_SERVICE_UNAVAILABLE);
+            }
+            
+            PageResponseWrapper<OrderSummaryResponse> pageResponseWrapper = response.getData();
+            
+            return PageResponse.of(
+                    pageResponseWrapper.getContent(),
+                    pageResponseWrapper.getPage() != null ? pageResponseWrapper.getPage() : page,
+                    pageResponseWrapper.getSize() != null ? pageResponseWrapper.getSize() : size,
+                    pageResponseWrapper.getTotalElements() != null ? pageResponseWrapper.getTotalElements() : 0L
+            );
+
+        } catch (UserException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("Order Service 호출 실패: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.ORDER_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("Order Service 호출 실패: userId={}, error={}", userId, e.getMessage(), e);
+            throw new UserException(UserErrorCode.ORDER_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * 서비스 기본 URL 조회
+     */
+    private String getBaseUrl() {
+        if (discoveryEnabled) {
+            try {
+                ServiceInstance instance = discoveryClient.getInstances(orderServiceName)
+                        .stream()
+                        .findFirst()
+                        .orElse(null);
+
+                if (instance != null) {
+                    return instance.getUri().toString();
+                }
+            } catch (Exception e) {
+                log.warn("Eureka에서 Order Service 인스턴스를 찾을 수 없습니다: {}", e.getMessage());
+            }
+        }
+        return orderServiceUrl;
+    }
+
+    /**
+     * ApiResponse 래퍼 DTO (역직렬화 문제 해결용)
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ApiResponseWrapper<T> {
+        @JsonProperty("data")
+        private T data;
+    }
+
+    /**
+     * PageResponse 래퍼 DTO (역직렬화 문제 해결용)
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PageResponseWrapper<T> {
+        @JsonProperty("content")
+        private java.util.List<T> content;
+        
+        @JsonProperty("totalElements")
+        private Long totalElements;
+        
+        @JsonProperty("page")
+        private Integer page;
+        
+        @JsonProperty("size")
+        private Integer size;
+    }
+
+    /**
+     * 주문 요약 응답 DTO
+     * Order 서비스의 전체 응답 구조를 그대로 반영 (다른 곳에서도 사용 가능)
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OrderSummaryResponse {
+        @JsonProperty("orderId")
+        private String orderId;
+        
+        @JsonProperty("userId")
+        private UUID userId;
+        
+        @JsonProperty("auctionId")
+        private String auctionId;
+        
+        @JsonProperty("shoeId")
+        private String shoeId;
+        
+        @JsonProperty("status")
+        private String status;
+        
+        @JsonProperty("amount")
+        private Long amount;
+        
+        @JsonProperty("usedPointAmount")
+        private Long usedPointAmount;
+        
+        @JsonProperty("paymentExpiredAt")
+        private LocalDateTime paymentExpiredAt;
+        
+        @JsonProperty("createdAt")
+        private LocalDateTime createdAt;
+        
+        @JsonProperty("updatedAt")
+        private LocalDateTime updatedAt;
+        
+        @JsonProperty("productName")
+        private String productName;
+        
+        @JsonProperty("auctionTitle")
+        private String auctionTitle;
+        
+        @JsonProperty("auctionStartTime")
+        private LocalDateTime auctionStartTime;
+    }
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/advice/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/advice/GlobalExceptionHandler.java
@@ -111,6 +111,27 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 잘못된 인자 예외 처리
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException e) {
+        log.warn("잘못된 인자: {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .success(false)
+                .errorCode(UserErrorCode.BAD_REQUEST.getErrorCode())
+                .message(e.getMessage())
+                .status(UserErrorCode.BAD_REQUEST.getStatus().value())
+                .data(null)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    /**
      * 기타 예외 처리 (서버 오류)
      */
     @ExceptionHandler(Exception.class)

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/MemberController.java
@@ -20,6 +20,8 @@ import com.bidket.user.application.service.PasswordChangeService;
 import com.bidket.user.application.service.ProfileUpdateService;
 import com.bidket.user.application.service.SignupService;
 import com.bidket.user.application.service.SocialLoginService;
+import com.bidket.user.application.service.HistoryService;
+import com.bidket.user.global.security.AuthorizationTokenValidator;
 import com.bidket.user.presentation.dto.request.BlacklistRegisterRequest;
 import com.bidket.user.presentation.dto.request.LoginRequest;
 import com.bidket.user.presentation.dto.request.MemberDeactivationRequest;
@@ -64,6 +66,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -98,6 +101,7 @@ public class MemberController {
     private final ProfileUpdateService profileUpdateService;
     private final PasswordChangeService passwordChangeService;
     private final MemberDeactivationService memberDeactivationService;
+    private final HistoryService historyService;
 
     /**
      * 이메일 중복 체크 API
@@ -611,6 +615,54 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
+    }
+
+    /**
+     * 입찰/주문 내역 조회 API
+     * type=BID인 경우: Auction 서비스의 "내 입찰 내역" API를 호출
+     * type=ORDER인 경우: Order 서비스의 "내 주문/결제 내역" API를 호출
+     * Authorization 헤더에 Bearer JWT 토큰이 필요
+     * @param page 페이지 번호 (0부터 시작, 기본값 0)
+     * @param size 페이지 사이즈 (기본값 20)
+     * @param type 히스토리 타입 (BID 또는 ORDER, 기본값 BID)
+     * @param authorization Authorization 헤더 값 (Bearer 토큰)
+     * @return 입찰/주문 내역 조회 응답
+     */
+    @Operation(
+            summary = "입찰/주문 내역 조회",
+            description = "현재 로그인한 사용자의 활동 내역을 조회합니다. type=BID인 경우 Auction 서비스를 호출하고, type=ORDER인 경우 Order 서비스를 호출합니다.",
+            tags = {"02. 회원 정보"},
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/history")
+    public ResponseEntity<?> getHistory(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(defaultValue = "0"))
+            @RequestParam(required = false) Integer page,
+            @Parameter(description = "페이지 사이즈", example = "20", schema = @Schema(defaultValue = "20"))
+            @RequestParam(required = false) Integer size,
+            @Parameter(description = "히스토리 타입 (BID 또는 ORDER)", example = "BID", schema = @Schema(defaultValue = "BID"))
+            @RequestParam(required = false) String type,
+            @RequestHeader(value = "Authorization") String authorization) {
+        
+        // Authorization 헤더 검증 및 정규화 (Bearer 형식 보장)
+        // 검증과 전송에 동일한 정규화된 값을 사용하여 일관성 보장
+        String normalizedAuthorization = AuthorizationTokenValidator.validateAndNormalize(authorization);
+        
+        // 기본값 설정
+        String historyType = (type != null && !type.isEmpty()) ? type : "BID";
+        
+        // 타입에 따라 다른 응답 반환
+        Object response = historyService.getHistory(page, size, type, normalizedAuthorization);
+        
+        if ("ORDER".equalsIgnoreCase(historyType)) {
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(ApiResponse.success("주문 내역 조회에 성공했습니다.", response));
+        } else {
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(ApiResponse.success("입찰 내역 조회에 성공했습니다.", response));
+        }
     }
 }
 

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/BidHistoryItemResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/BidHistoryItemResponse.java
@@ -1,0 +1,43 @@
+package com.bidket.user.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 입찰 내역 항목 응답 DTO
+ */
+@Builder
+public record BidHistoryItemResponse(
+        /** 입찰 ID */
+        UUID id,
+        
+        /** 경매 ID */
+        UUID auctionId,
+        
+        /** 입찰자 ID */
+        UUID bidderId,
+        
+        /** 입찰금액 */
+        Long amount,
+        
+        /** 입찰 중 최고가 여부 */
+        Boolean highest,
+        
+        /** 입찰 상태값 */
+        String status,
+        
+        /** 입찰 순위 */
+        Integer rank,
+        
+        /** 낙찰 후 주문 ID (있을 때만) */
+        UUID orderId,
+        
+        /** 생성 시각 */
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/BidHistoryResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/BidHistoryResponse.java
@@ -1,0 +1,25 @@
+package com.bidket.user.presentation.dto.response;
+
+import java.util.List;
+
+/**
+ * 입찰 내역 조회 응답 DTO (페이지네이션 포함)
+ */
+public record BidHistoryResponse(
+        /** 입찰 내역 목록 */
+        List<BidHistoryItemResponse> content,
+        
+        /** 전체 건수 */
+        Long totalElements,
+        
+        /** 전체 페이지 수 */
+        Integer totalPages,
+        
+        /** 현재 페이지 번호 */
+        Integer page,
+        
+        /** 페이지 사이즈 */
+        Integer size
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/OrderHistoryItemResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/OrderHistoryItemResponse.java
@@ -1,0 +1,38 @@
+package com.bidket.user.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 주문 내역 항목 응답 DTO
+ */
+@Builder
+public record OrderHistoryItemResponse(
+        /** 주문 ID */
+        UUID orderId,
+        
+        /** 주문 상태값 */
+        String status,
+        
+        /** 주문금액 */
+        Long amount,
+        
+        /** 상품명 */
+        String productName,
+        
+        /** 경매 제목 */
+        String auctionTitle,
+        
+        /** 경매 시작 시간 */
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime auctionStartTime,
+        
+        /** 생성 시각 */
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {
+}
+

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/OrderHistoryResponse.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/dto/response/OrderHistoryResponse.java
@@ -1,0 +1,31 @@
+package com.bidket.user.presentation.dto.response;
+
+import java.util.List;
+
+/**
+ * 주문 내역 조회 응답 DTO (페이지네이션 포함)
+ */
+public record OrderHistoryResponse(
+        /** 현재 페이지 번호 */
+        Integer page,
+        
+        /** 페이지 사이즈 */
+        Integer size,
+        
+        /** 전체 건수 */
+        Long totalElements,
+        
+        /** 전체 페이지 수 */
+        Integer totalPages,
+        
+        /** 다음 페이지 존재 여부 */
+        Boolean hasNext,
+        
+        /** 이전 페이지 존재 여부 */
+        Boolean hasPrevious,
+        
+        /** 주문 내역 목록 */
+        List<OrderHistoryItemResponse> content
+) {
+}
+

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -48,3 +48,14 @@ google:
 springdoc:
   swagger-ui:
     tags-sorter: alpha
+
+services:
+  auction-service:
+    name: auction-service
+    url: http://localhost:8300
+  order-service:
+    name: order-service
+    url: http://localhost:8500
+  product-service:
+    name: product-service
+    url: http://localhost:8400


### PR DESCRIPTION
## Issue Number
- closed #[165]

## Description
회원 활동 내역 조회 API(/v1/members/history)
BID 타입: Auction 서비스의 내 입찰 내역 연동
ORDER 타입: Order 서비스의 내 주문/결제 내역 연동
HistoryService에서 타입별 조회 로직 분기 처리
응답 DTO 구현
AuctionServiceClient / OrderServiceClient 외부 서비스 호출 로직 구현

## Test Result
<img width="1147" height="811" alt="image" src="https://github.com/user-attachments/assets/cc02e3b1-4df6-426a-9451-f8cd045e23a6" />
<img width="1148" height="647" alt="image" src="https://github.com/user-attachments/assets/b7844316-95da-45b5-bbc0-87cd045aaa0e" />


## To Reviewer

