### PR TITLE
Fix/#167 Google 로그인 테스트 페이지에 환경 변수 주입 기능 추가

### DIFF
--- a/backend/user-service/src/main/java/com/bidket/user/global/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/com/bidket/user/global/config/SecurityConfig.java
@@ -43,10 +43,10 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v1/members/signup", "/v1/members/login", "/v1/members/social-login", "/v1/members/token/refresh", "/v1/members/check-email", "/v1/members/check-nickname").permitAll()
+                        .requestMatchers("/v1/members/signup", "/v1/members/login", "/v1/members/social-login", "/v1/members/token/refresh", "/v1/members/check-email", "/v1/members/check-nickname", "/v1/members/google-client-id").permitAll()
                         .requestMatchers("/api/v1/users/**").permitAll()  // 내부 서비스 간 통신용 API (추후 서비스 간 인증 추가 고려)
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/*.html", "/static/**").permitAll()  // 테스트용 HTML 파일 접근 허용
+                        .requestMatchers("/*.html", "/static/**", "/google-login-test.html").permitAll()  // 테스트용 HTML 파일 접근 허용
                         .anyRequest().authenticated()  // 인증이 필요한 엔드포인트
                 );
 

--- a/backend/user-service/src/main/java/com/bidket/user/presentation/api/GoogleLoginTestController.java
+++ b/backend/user-service/src/main/java/com/bidket/user/presentation/api/GoogleLoginTestController.java
@@ -1,0 +1,44 @@
+package com.bidket.user.presentation.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Google 로그인 테스트 페이지 컨트롤러
+ * 환경 변수에서 Google Client ID를 주입하여 HTML을 반환합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+public class GoogleLoginTestController {
+
+    @Value("${google.client-id}")
+    private String googleClientId;
+
+    /**
+     * Google 로그인 테스트 페이지 반환
+     * HTML 파일의 ${GOOGLE_CLIENT_ID} 플레이스홀더를 실제 환경 변수 값으로 치환
+     */
+    @GetMapping(value = "/google-login-test.html", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> getGoogleLoginTestPage() throws IOException {
+        // HTML 파일 읽기
+        ClassPathResource resource = new ClassPathResource("static/google-login-test.html");
+        String htmlContent = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+        
+        // 플레이스홀더를 실제 값으로 치환
+        String processedHtml = htmlContent.replace("${GOOGLE_CLIENT_ID}", googleClientId);
+        
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_HTML)
+                .body(processedHtml);
+    }
+}
+

--- a/backend/user-service/src/main/resources/static/google-login-test.html
+++ b/backend/user-service/src/main/resources/static/google-login-test.html
@@ -258,8 +258,8 @@ Swagger 테스트용 Google idToken 발급 페이지
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     
     <script>
-        // Google Client ID
-        const GOOGLE_CLIENT_ID = 'GOOGLE_CLIENT_ID';
+        // Google Client ID (환경 변수에서 주입됨)
+        const GOOGLE_CLIENT_ID = '${GOOGLE_CLIENT_ID}';
         
         let idToken = null;
         let userInfo = null;


### PR DESCRIPTION
## Issue Number
- closed #[167]

## Description
- HTML 파일에서 Google Client ID를 환경 변수로부터 주입받도록 수정
- GoogleLoginTestController 추가: HTML 파일의 플레이스홀더를 환경 변수 값으로 치환
- SecurityConfig에 /google-login-test.html 엔드포인트 접근 허용 추가

## Test Result
<img width="980" height="1083" alt="image" src="https://github.com/user-attachments/assets/16ee0d86-f094-46cf-b66c-88bdf584ddab" />


## To Reviewer
- 리뷰 포인트
