### PR TITLE
Fix/#172 cicd 이미지 태그 오류로 인한 배포 실패 문제 해결

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -64,14 +64,38 @@ jobs:
       - name: Run app deployment script
         run: |
           ssh -p 2222 ubuntu@${{ secrets.EC2_APP_HOST }} << 'EOF'
-            export GATEWAY_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
-            export USER_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
-            export PRODUCT_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
-            export ORDER_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
-            export AUCTION_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
-            export NOTIFICATION_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
-            export QUEUE_IMAGE_TAG='${{ github.event.workflow_run.head_sha }}'
+            set -e
+            cd /opt/bidket/app
+          
+            SHA="${{ github.event.workflow_run.head_sha }}"
 
+            case "${{ github.event.workflow_run.name }}" in
+              "Build & Push Gateway Service Image")
+                sed -i "s/^GATEWAY_IMAGE_TAG=.*/GATEWAY_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              "Build & Push User Service Image")
+                sed -i "s/^USER_IMAGE_TAG=.*/USER_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              "Build & Push Product Service Image")
+                sed -i "s/^PRODUCT_IMAGE_TAG=.*/PRODUCT_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              "Build & Push Order Service Image")
+                sed -i "s/^ORDER_IMAGE_TAG=.*/ORDER_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              "Build & Push Auction Service Image")
+                sed -i "s/^AUCTION_IMAGE_TAG=.*/AUCTION_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              "Build & Push Notification Service Image")
+                sed -i "s/^NOTIFICATION_IMAGE_TAG=.*/NOTIFICATION_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              "Build & Push Queue Service Image")
+                sed -i "s/^QUEUE_IMAGE_TAG=.*/QUEUE_IMAGE_TAG=${SHA}/" .env.app
+                ;;
+              *)
+                echo "Unknown workflow trigger"
+                ;;
+            esac
+            
             chmod +x /opt/bidket/app/run-app.sh
             bash /opt/bidket/app/run-app.sh
           EOF

--- a/run-app.sh
+++ b/run-app.sh
@@ -33,22 +33,6 @@ trap rollback ERR
 
 
 # ============================
-# function
-# ============================
-set_env() {
-  local KEY=$1
-  local VALUE=$2
-  local FILE=$3
-
-  if grep -q "^${KEY}=" "$FILE"; then
-    sed -i "s|^${KEY}=.*|${KEY}=${VALUE}|" "$FILE"
-  else
-    echo "${KEY}=${VALUE}" >> "$FILE"
-  fi
-}
-
-
-# ============================
 # Bidket App Deployment Script
 # ============================
 
@@ -61,24 +45,6 @@ cd "$APP_DIR"
 
 # Backup env
 cp "$ENV_FILE" "$BACKUP_FILE"
-
-# required env validation(태그 없는 배포 막기)
-: "${GATEWAY_IMAGE_TAG:?GATEWAY_IMAGE_TAG is required}"
-: "${USER_IMAGE_TAG:?USER_IMAGE_TAG is required}"
-: "${PRODUCT_IMAGE_TAG:?PRODUCT_IMAGE_TAG is required}"
-: "${ORDER_IMAGE_TAG:?ORDER_IMAGE_TAG is required}"
-: "${AUCTION_IMAGE_TAG:?AUCTION_IMAGE_TAG is required}"
-: "${NOTIFICATION_IMAGE_TAG:?NOTIFICATION_IMAGE_TAG is required}"
-: "${QUEUE_IMAGE_TAG:?QUEUE_IMAGE_TAG is required}"
-
-# Image Tag setting
-set_env GATEWAY_IMAGE_TAG "$GATEWAY_IMAGE_TAG" "$ENV_FILE"
-set_env USER_IMAGE_TAG "$USER_IMAGE_TAG" "$ENV_FILE"
-set_env PRODUCT_IMAGE_TAG "$PRODUCT_IMAGE_TAG" "$ENV_FILE"
-set_env ORDER_IMAGE_TAG "$ORDER_IMAGE_TAG" "$ENV_FILE"
-set_env AUCTION_IMAGE_TAG "$AUCTION_IMAGE_TAG" "$ENV_FILE"
-set_env NOTIFICATION_IMAGE_TAG "$NOTIFICATION_IMAGE_TAG" "$ENV_FILE"
-set_env QUEUE_IMAGE_TAG "$QUEUE_IMAGE_TAG" "$ENV_FILE"
 
 echo "📌 Step 2. 최신 이미지 Pull (app 전용)"
 docker compose \


### PR DESCRIPTION
## Issue Number
- closed #172 

## Description
  - 모든 서비스에 동일한 이미지 태그 적용하던 구조 삭제
  - 빌드된 서비스만 이미지 태그 갱신하도록 수정(workflow_run 트리거 기준으로 변경된 서비스의 이미지 태그만 갱신)
  - run-app.sh에 이미지 태그 변경 로직 제거(validation, env_set() 제거)
  - deploy에서 이미지 태그 업데이트 로직 추가

## Test Result
.

## To Reviewer
기존 deploy 워크플로우에서 트리거 된 서비스와 상관없이 모든 서비스를 동일한 SHA를 적용하도록 하는 오류가 있었습니다.
그래서 배포 과정에서 docker registry에 존재하지 않는 이미지로 인한 배포 실패 문제가 발생했습니다.

배포 단계에서 변경된 서비스의 태그만 선택적으로 갱신하도록 수정했습니다.
배포 스크립트는 배포, 롤백의 책임만 가지고, 배포 워크플로우에서 태그 결정을 하는 구조로 변경했습니다.
